### PR TITLE
OP007: EventBus abstraction, simplify stream wiring

### DIFF
--- a/delivery/src/service.py
+++ b/delivery/src/service.py
@@ -15,23 +15,24 @@ class DeliveryService:
         self._repo = repo
         self._publisher = publisher
 
-    async def handle_order(self, order_data: dict[str, Any]) -> None:
-        if order_data.get("status") != self.OUT_FOR_DELIVERY:
-            logging.info("Skipping order %s, status not '%s'", order_data.get("id"), self.OUT_FOR_DELIVERY)
+    async def handle_order(self, msg: Any) -> None:
+        if msg.status != self.OUT_FOR_DELIVERY:
+            logging.info("Skipping order %s, status not '%s'", msg.id, self.OUT_FOR_DELIVERY)
             return
 
-        delivery = DeliverySchema(order_id=order_data["id"])
+        delivery = DeliverySchema(order_id=msg.id)
         delivery_id = await self._repo.create(delivery)
         logging.info("Created delivery %s", delivery_id)
 
         await self._publisher.publish_raw(settings.deliveries_stream, delivery.model_dump(mode="json"))
 
-        if order_data.get("simulator") != -1:
-            await self._publisher.publish_raw(settings.simulate_delivery_stream, order_data)
+        if getattr(msg, "simulation", 1) != -1:
+            await self._publisher.publish_raw(settings.simulate_delivery_stream, msg.model_dump(mode="json"))
             logging.info("Simulating delivery for %s", delivery_id)
 
-    async def handle_status_update(self, status_data: dict[str, Any]) -> None:
-        if not (order_id := status_data.get("order_id") or status_data.get("id")):
+    async def handle_status_update(self, msg: Any) -> None:
+        order_id = getattr(msg, "order_id", None) or msg.id
+        if not order_id:
             raise ValueError("DeliveryService.handle_status_update: Missing order_id in status update")
 
         delivery = await self._repo.find_one({"order_id": order_id})
@@ -39,7 +40,7 @@ class DeliveryService:
         if not (delivery and delivery.id):
             raise ValueError(f"DeliveryService.handle_status_update: Delivery not found for order_id {order_id}")
 
-        new_status = DeliveryStatus(status_data["status"])
+        new_status = DeliveryStatus(msg.status)
 
         if await self._repo.update_status(delivery.id, new_status):
             delivery.status = new_status

--- a/delivery/src/streams.py
+++ b/delivery/src/streams.py
@@ -1,11 +1,6 @@
-import asyncio
-import socket
-import uuid
-from collections.abc import Awaitable
-
 from fastapi import FastAPI
 from pydantic import BaseModel
-from shared.redis.consumer import StreamConsumer
+from shared.redis.event_bus import EventBus
 
 from src.settings import settings
 
@@ -24,46 +19,13 @@ class DeliveryStatusEvent(BaseModel):
 
 async def setup_streams(app: FastAPI) -> None:
     service = app.state.delivery_service
-    redis = app.state.redis_client
-    hostname = socket.gethostname()
-    short_id = uuid.uuid4().hex[:6]
-    consumer_name = f"delivery-{hostname}-{short_id}"
-
-    orders_consumer: StreamConsumer[OrderEvent] = StreamConsumer(
-        redis=redis,
-        stream=settings.orders_stream,
-        group=settings.delivery_group,
-        consumer_name=consumer_name,
-        message_type=OrderEvent,
-    )
-    status_consumer: StreamConsumer[DeliveryStatusEvent] = StreamConsumer(
-        redis=redis,
-        stream=settings.delivery_status_stream,
-        group=settings.delivery_group,
-        consumer_name=consumer_name,
-        message_type=DeliveryStatusEvent,
-    )
-
-    async def handle_order(msg: OrderEvent) -> None:
-        await service.handle_order(msg.model_dump())
-
-    async def handle_status(msg: DeliveryStatusEvent) -> None:
-        await service.handle_status_update(msg.model_dump())
-
-    app.state.subscription_task = asyncio.create_task(
-        _run_streams(orders_consumer.listen(handle_order), status_consumer.listen(handle_status))
-    )
-
-
-async def _run_streams(*streams: Awaitable[None]) -> None:
-    await asyncio.gather(*streams)
+    bus = EventBus(app.state.redis_client, group=settings.delivery_group)
+    bus.subscribe(settings.orders_stream, OrderEvent, service.handle_order)
+    bus.subscribe(settings.delivery_status_stream, DeliveryStatusEvent, service.handle_status_update)
+    await bus.start()
+    app.state.event_bus = bus
 
 
 async def stop_streams(app: FastAPI) -> None:
-    task = getattr(app.state, "subscription_task", None)
-    if task and not task.done():
-        task.cancel()
-        try:
-            await asyncio.wait_for(task, timeout=5)
-        except asyncio.CancelledError:
-            pass
+    if bus := getattr(app.state, "event_bus", None):
+        await bus.stop()

--- a/notifications/src/service.py
+++ b/notifications/src/service.py
@@ -11,11 +11,11 @@ class NotificationService:
         self._repo = repo
         self._ws_manager = ws_manager
 
-    async def handle_event(self, data: dict[str, Any]) -> None:
-        order_id = data.get("order_id") or data.get("id")
-        status = data.get("status")
+    async def handle_event(self, msg: Any) -> None:
+        order_id = getattr(msg, "order_id", None) or getattr(msg, "id", None)
+        status = getattr(msg, "status", None)
         if not (order_id and status):
-            raise ValueError(f"NotificationService.handle_event: Invalid data received: {data}")
+            raise ValueError(f"NotificationService.handle_event: Invalid data received: {msg}")
 
         cache = CacheSchema(order_id=order_id, status=status).model_dump(mode="json")
 

--- a/notifications/src/streams.py
+++ b/notifications/src/streams.py
@@ -1,11 +1,6 @@
-import asyncio
-import socket
-import uuid
-from collections.abc import Awaitable
-
 from fastapi import FastAPI
 from pydantic import BaseModel
-from shared.redis.consumer import StreamConsumer
+from shared.redis.event_bus import EventBus
 
 from src.settings import settings
 
@@ -17,46 +12,14 @@ class EventMessage(BaseModel):
 
 
 async def setup_streams(app: FastAPI) -> None:
-    hostname = socket.gethostname()
-    short_id = uuid.uuid4().hex[:6]
-    consumer_name = f"notifications-{hostname}-{short_id}"
-
     service = app.state.notification_service
-    redis = app.state.redis_client
-
-    orders_consumer: StreamConsumer[EventMessage] = StreamConsumer(
-        redis=redis,
-        stream=settings.orders_stream,
-        group=settings.notifications_group,
-        consumer_name=consumer_name,
-        message_type=EventMessage,
-    )
-
-    deliveries_consumer: StreamConsumer[EventMessage] = StreamConsumer(
-        redis=redis,
-        stream=settings.deliveries_stream,
-        group=settings.notifications_group,
-        consumer_name=consumer_name,
-        message_type=EventMessage,
-    )
-
-    async def handle_event(msg: EventMessage) -> None:
-        await service.handle_event(msg.model_dump(exclude_none=True))
-
-    app.state.subscription_task = asyncio.create_task(
-        _run_streams(orders_consumer.listen(handle_event), deliveries_consumer.listen(handle_event))
-    )
-
-
-async def _run_streams(*streams: Awaitable[None]) -> None:
-    await asyncio.gather(*streams)
+    bus = EventBus(app.state.redis_client, group=settings.notifications_group)
+    bus.subscribe(settings.orders_stream, EventMessage, service.handle_event)
+    bus.subscribe(settings.deliveries_stream, EventMessage, service.handle_event)
+    await bus.start()
+    app.state.event_bus = bus
 
 
 async def stop_streams(app: FastAPI) -> None:
-    task = getattr(app.state, "subscription_task", None)
-    if task and not task.done():
-        task.cancel()
-        try:
-            await asyncio.wait_for(task, timeout=5)
-        except asyncio.CancelledError:
-            pass
+    if bus := getattr(app.state, "event_bus", None):
+        await bus.stop()

--- a/orders/src/services/order_service.py
+++ b/orders/src/services/order_service.py
@@ -70,8 +70,7 @@ class OrderService(TransactionServiceMixin):
 
         return OrderResponse(order=None, success=False, message="Order not found or update failed")
 
-    async def handle_status_update(self, data: dict[str, str]) -> None:
-        order_id = data["id"]
-        status = OrderStatus(data["status"])
-        logging.info("Order %s updated to %s", order_id, status)
-        await self.update_order_status(order_id, status)
+    async def handle_status_update(self, msg: Any) -> None:
+        status = OrderStatus(msg.status)
+        logging.info("Order %s updated to %s", msg.id, status)
+        await self.update_order_status(msg.id, status)

--- a/orders/src/streams.py
+++ b/orders/src/streams.py
@@ -1,10 +1,6 @@
-import asyncio
-import socket
-import uuid
-
 from fastapi import FastAPI
 from pydantic import BaseModel
-from shared.redis.consumer import StreamConsumer
+from shared.redis.event_bus import EventBus
 
 from src.settings import settings
 
@@ -15,30 +11,12 @@ class StatusUpdateMessage(BaseModel):
 
 
 async def setup_streams(app: FastAPI) -> None:
-    redis = app.state.redis_client
-    service = app.state.order_service
-    hostname = socket.gethostname()
-    short_id = uuid.uuid4().hex[:6]
-
-    consumer: StreamConsumer[StatusUpdateMessage] = StreamConsumer(
-        redis=redis,
-        stream=settings.order_status_stream,
-        group=settings.orders_group,
-        consumer_name=f"order-{hostname}-{short_id}",
-        message_type=StatusUpdateMessage,
-    )
-
-    async def handle_status_update(msg: StatusUpdateMessage) -> None:
-        await service.handle_status_update({"id": msg.id, "status": msg.status})
-
-    app.state.subscription_task = asyncio.create_task(consumer.listen(handle_status_update))
+    bus = EventBus(app.state.redis_client, group=settings.orders_group)
+    bus.subscribe(settings.order_status_stream, StatusUpdateMessage, app.state.order_service.handle_status_update)
+    await bus.start()
+    app.state.event_bus = bus
 
 
 async def stop_streams(app: FastAPI) -> None:
-    task = getattr(app.state, "subscription_task", None)
-    if task and not task.done():
-        task.cancel()
-        try:
-            await asyncio.wait_for(task, timeout=5)
-        except asyncio.CancelledError:
-            pass
+    if bus := getattr(app.state, "event_bus", None):
+        await bus.stop()

--- a/shared/src/shared/__init__.py
+++ b/shared/src/shared/__init__.py
@@ -2,6 +2,7 @@ from shared.db.mongo import MongoTransactionManager, connect_mongo
 from shared.db.repository import MongoRepository
 from shared.redis.connection import connect_redis
 from shared.redis.consumer import StreamConsumer
+from shared.redis.event_bus import EventBus
 from shared.redis.publisher import StreamProducer
 from shared.schemas.base import BaseDocument, StrObjectId
 from shared.settings import BaseServiceSettings, EnvironmentEnum
@@ -10,6 +11,7 @@ __all__ = [
     "BaseDocument",
     "BaseServiceSettings",
     "EnvironmentEnum",
+    "EventBus",
     "MongoRepository",
     "MongoTransactionManager",
     "StreamConsumer",

--- a/shared/src/shared/redis/event_bus.py
+++ b/shared/src/shared/redis/event_bus.py
@@ -1,0 +1,72 @@
+import asyncio
+import logging
+import socket
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel
+from redis.asyncio import Redis
+
+from shared.redis.consumer import StreamConsumer
+
+T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass
+class _Subscription(Generic[T]):
+    stream: str
+    model: type[T]
+    handler: Callable[[T], Awaitable[None]]
+
+
+class EventBus:
+    """Lightweight wrapper around StreamConsumer that manages subscriptions and task lifecycle."""
+
+    def __init__(self, redis: Redis, *, group: str) -> None:
+        self._redis = redis
+        self._group = group
+        self._consumer_name = f"{group}-{socket.gethostname()}-{uuid.uuid4().hex[:6]}"
+        self._subscriptions: list[_Subscription[Any]] = []
+        self._tasks: list[asyncio.Task[None]] = []
+
+    def subscribe(self, stream: str, model: type[T], handler: Callable[[T], Awaitable[None]]) -> None:
+        self._subscriptions.append(_Subscription(stream=stream, model=model, handler=handler))
+
+    async def start(self) -> None:
+        for sub in self._subscriptions:
+            consumer: StreamConsumer[Any] = StreamConsumer(
+                redis=self._redis,
+                stream=sub.stream,
+                group=self._group,
+                consumer_name=self._consumer_name,
+                message_type=sub.model,
+            )
+            task = asyncio.create_task(consumer.listen(sub.handler))
+            self._tasks.append(task)
+
+        logging.info(
+            "EventBus started: %d subscription(s) in group '%s'",
+            len(self._tasks),
+            self._group,
+        )
+
+    async def run_forever(self) -> None:
+        """Start all consumers and block until they complete or are cancelled."""
+        await self.start()
+        await asyncio.gather(*self._tasks)
+
+    async def stop(self) -> None:
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+
+        results = await asyncio.gather(*self._tasks, return_exceptions=True)
+
+        for result in results:
+            if isinstance(result, Exception) and not isinstance(result, asyncio.CancelledError):
+                logging.error("EventBus task error during shutdown: %s", result)
+
+        self._tasks.clear()
+        logging.info("EventBus stopped for group '%s'", self._group)

--- a/simulator/src/schemas.py
+++ b/simulator/src/schemas.py
@@ -4,14 +4,12 @@ from src.settings import settings
 
 
 class SimulationStream(Enum):
-    """(listen_stream, send_stream)"""
-
     ORDER = (settings.simulate_order_stream, settings.order_status_stream)
     DELIVERY = (settings.simulate_delivery_stream, settings.delivery_status_stream)
 
-    def __init__(self, listen_stream: str, send_stream: str) -> None:
-        self.listen_stream = listen_stream
-        self.send_stream = send_stream
+    def __init__(self, source: str, target: str) -> None:
+        self.source = source
+        self.target = target
 
 
 class OrderStatus(str, Enum):

--- a/simulator/src/streams.py
+++ b/simulator/src/streams.py
@@ -1,12 +1,8 @@
-import asyncio
-import logging
-import socket
-import uuid
 from typing import Any
 
 from pydantic import BaseModel
 from redis.asyncio import Redis
-from shared.redis.consumer import StreamConsumer
+from shared.redis.event_bus import EventBus
 from shared.redis.publisher import StreamProducer
 
 from src.schemas import SimulationStream
@@ -20,26 +16,7 @@ class SimulationEvent(BaseModel):
 
 
 async def start_streams(redis: Redis) -> None:
-    hostname = socket.gethostname()
-    short_id = uuid.uuid4().hex[:6]
-    consumer_name = f"simulator-{hostname}-{short_id}"
-
     producer: StreamProducer[Any] = StreamProducer(redis)
-
-    order_consumer: StreamConsumer[SimulationEvent] = StreamConsumer(
-        redis=redis,
-        stream=settings.simulate_order_stream,
-        group=settings.simulator_group,
-        consumer_name=consumer_name,
-        message_type=SimulationEvent,
-    )
-    delivery_consumer: StreamConsumer[SimulationEvent] = StreamConsumer(
-        redis=redis,
-        stream=settings.simulate_delivery_stream,
-        group=settings.simulator_group,
-        consumer_name=consumer_name,
-        message_type=SimulationEvent,
-    )
 
     async def handle_order(msg: SimulationEvent) -> None:
         await handle_simulation_event(SimulationStream.ORDER, msg.model_dump(), producer)
@@ -47,8 +24,7 @@ async def start_streams(redis: Redis) -> None:
     async def handle_delivery(msg: SimulationEvent) -> None:
         await handle_simulation_event(SimulationStream.DELIVERY, msg.model_dump(), producer)
 
-    order_task = asyncio.create_task(order_consumer.listen(handle_order))
-    delivery_task = asyncio.create_task(delivery_consumer.listen(handle_delivery))
-
-    logging.info("Simulation workers started for ORDER and DELIVERY streams")
-    await asyncio.gather(order_task, delivery_task)
+    bus = EventBus(redis, group=settings.simulator_group)
+    bus.subscribe(settings.simulate_order_stream, SimulationEvent, handle_order)
+    bus.subscribe(settings.simulate_delivery_stream, SimulationEvent, handle_delivery)
+    await bus.run_forever()

--- a/simulator/src/utils.py
+++ b/simulator/src/utils.py
@@ -20,10 +20,10 @@ async def handle_simulation_event(
         logging.warning("No simulation strategy found for stream: %s", stream)
         return
 
-    logging.info("Received simulation event for `%s` on `%s`", data.get("id"), stream.listen_stream)
+    logging.info("Received simulation event for `%s` on `%s`", data.get("id"), stream.source)
 
     async def run() -> None:
         async with SEMAPHORE:
-            await strategy.process(entity_id=data["id"], producer=producer, output_stream=stream.send_stream)
+            await strategy.process(entity_id=data["id"], producer=producer, output_stream=stream.target)
 
     asyncio.create_task(run())


### PR DESCRIPTION
## Summary
- Add shared `EventBus` class that manages `StreamConsumer` lifecycle (subscribe, start, stop)
- Replace per-service boilerplate (~50 lines each) with `bus.subscribe()` + `bus.start()/stop()` (~10 lines each)
- Rename `SimulationStream` fields: `listen_stream`/`send_stream` → `source`/`target`
- Update service handlers to accept Pydantic models directly from EventBus instead of `dict`

## Stream architecture (verified, no changes needed)
6 streams, all justified:
- `orders-stream` → fan-out to delivery + notifications
- `deliveries-stream` → fan-out to notifications  
- `simulate-order-stream` / `simulate-delivery-stream` → trigger simulator
- `order-status-stream` / `delivery-status-stream` → simulator → services

## Test plan
- [x] `ruff check` + `ty check` pass for all 4 services
- [x] All 4 Docker images build successfully
- [x] `EventBus` import verified inside Docker containers
- [x] CI checks (push triggered)