### PR TITLE
OP009: Typed AppState, Prometheus metrics, dev tools & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,35 @@ Includes:
 | `mongo`                  | 27017 | MongoDB replica (1-node)                            |
 | `redis`                  | 6379  | Redis for pub/sub & messaging                       |
 | `stock-refill` (CronJob) | -     | Periodically refills inventory stock                |
+| `prometheus`             | 9090  | Metrics collection & PromQL queries                 |
+| `grafana`                | 3001  | Dashboards & visualization (proxied at `/grafana/`)  |
+| `loki`                   | 3100  | Log aggregation backend                              |
+| `promtail`               | -     | Collects container logs and ships to Loki            |
+| `nginx`                  | 80    | Reverse proxy for frontend, APIs & Grafana           |
+
+---
+
+## 📊 Monitoring & Observability
+
+The project includes a full observability stack:
+
+- **Prometheus** — scrapes `/metrics` from all FastAPI services every 15s
+- **Grafana** — dashboards and log exploration (Loki datasource pre-provisioned)
+- **Loki + Promtail** — aggregates container logs from Docker
+
+### Quick Links (Docker Compose)
+
+| Tool                        | URL                                  | Credentials     |
+|-----------------------------|--------------------------------------|-----------------|
+| Frontend                    | http://localhost                      | —               |
+| Dev Tools page              | http://localhost/dev                  | —               |
+| Grafana                     | http://localhost/grafana/             | admin / admin   |
+| Prometheus                  | http://localhost:9090                 | —               |
+| Order Service — API Docs    | http://localhost:8003/docs            | —               |
+| Delivery Service — API Docs | http://localhost:8001/docs            | —               |
+| Notifications — API Docs    | http://localhost:8002/docs            | —               |
+
+All service OpenAPI docs are available only in `DEVELOPMENT` environment.
 
 ---
 
@@ -176,11 +205,14 @@ Includes:
 ├── orders/                 # FastAPI – orders service
 ├── delivery/               # FastAPI – delivery logic
 ├── notifications/          # FastAPI – notifications + Redis
+├── shared/                 # Shared Python library (Redis, metrics, settings)
 ├── simulator/              # Just Python and streams – generates synthetic events
+├── monitoring/             # Prometheus, Grafana, Loki & Promtail configs
+├── nginx/                  # Nginx reverse proxy configs (dev & prod)
 ├── charts/                 # Helm chart & init jobs
 ├── envs/                   # All .env files required
-├── scripts/init-replica.sh # Replica init script (Docker)
-├── assets/*.png            # Diagrams
+├── scripts/                # Init scripts (replica, seed data)
+├── assets/                 # Architecture diagrams
 └── docker-compose.yaml     # Dev-only deployment stack
 ```
 
@@ -188,16 +220,11 @@ Includes:
 
 ## ✅ TODO
 
-- [ ]  Implement CQRS and Event Sourcing
-    
-- [ ]  Logging & monitoring (Prometheus, Grafana)—a log format is ready.
-    
-- [ ]  Set up cache invalidation via CronJob
-    
-- [ ]  Enhance Redis Stream consumers with XPENDING + XCLAIM logic
-
-- [ ]  UNIT tests for all services 
-    
+- [ ] Implement CQRS and Event Sourcing
+- [x] Logging & monitoring (Prometheus, Grafana, Loki)
+- [ ] Set up cache invalidation via CronJob
+- [x] Enhance Redis Stream consumers with XPENDING + XCLAIM logic
+- [ ] Unit tests for all services (orders covered, delivery & notifications pending)
 
 
 ## 🍺 Author

--- a/delivery/pyproject.toml
+++ b/delivery/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
 dev = [
     "ty>=0.0.1a7",
     "ruff==0.11.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
 ]
 
 [tool.uv.sources]

--- a/delivery/pytest.ini
+++ b/delivery/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+pythonpath = .

--- a/delivery/src/databases.py
+++ b/delivery/src/databases.py
@@ -1,20 +1,20 @@
-from fastapi import FastAPI
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
+from redis.asyncio import Redis
 from shared.db.mongo import connect_mongo
 from shared.redis.connection import connect_redis
 
 from src.settings import settings
 
 
-async def setup_databases(app: FastAPI) -> None:
-    app.state.mongo_client, app.state.database = await connect_mongo(settings.mongo_url, settings.mongo_db)
-    app.state.redis_client = await connect_redis(settings.redis_url)
+async def connect_databases() -> tuple[AsyncMongoClient, AsyncDatabase, Redis]:
+    mongo_client, database = await connect_mongo(settings.mongo_url, settings.mongo_db)
+    redis_client = await connect_redis(settings.redis_url)
+    return mongo_client, database, redis_client
 
 
-async def close_databases(app: FastAPI) -> None:
-    if redis := getattr(app.state, "redis_client", None):
-        await redis.close()
-    if mongo := getattr(app.state, "mongo_client", None):
-        await mongo.close()
-
-
-__all__ = ["setup_databases", "close_databases"]
+async def close_databases(*, mongo_client: AsyncMongoClient | None = None, redis_client: Redis | None = None) -> None:
+    if redis_client:
+        await redis_client.close()
+    if mongo_client:
+        await mongo_client.close()

--- a/delivery/src/lifespan.py
+++ b/delivery/src/lifespan.py
@@ -5,32 +5,43 @@ from fastapi import FastAPI
 from shared.logging import setup_logging
 from shared.redis.publisher import StreamProducer
 
-from src.databases import close_databases, setup_databases
+from src.databases import close_databases, connect_databases
 from src.repository import DeliveryRepository
 from src.service import DeliveryService
 from src.settings import settings
+from src.state import AppState
 from src.streams import setup_streams, stop_streams
 
 
 async def startup(app: FastAPI) -> None:
-    app.state.ready = False
     setup_logging()
-    await setup_databases(app)
+    mongo_client, database, redis_client = await connect_databases()
 
-    app.state.delivery_repo = DeliveryRepository(
-        collection=app.state.database.get_collection(settings.mongo_collection_deliveries),
+    delivery_repo = DeliveryRepository(
+        collection=database.get_collection(settings.mongo_collection_deliveries),
     )
 
-    publisher: StreamProducer[Any] = StreamProducer(app.state.redis_client, source="delivery-service")
-    app.state.delivery_service = DeliveryService(repo=app.state.delivery_repo, publisher=publisher)
+    publisher: StreamProducer[Any] = StreamProducer(redis_client, source="delivery-service")
 
-    await setup_streams(app)
-    app.state.ready = True
+    state = AppState(
+        mongo_client=mongo_client,
+        database=database,
+        redis_client=redis_client,
+        delivery_repo=delivery_repo,
+        delivery_service=DeliveryService(repo=delivery_repo, publisher=publisher),
+    )
+
+    await setup_streams(state)
+    state.ready = True
+    app.state.ctx = state
     logging.info("Delivery service is ready.")
 
 
 async def teardown(app: FastAPI) -> None:
-    app.state.ready = False
-    await stop_streams(app)
-    await close_databases(app)
+    state: AppState | None = getattr(app.state, "ctx", None)
+    if not state:
+        return
+    state.ready = False
+    await stop_streams(state)
+    await close_databases(mongo_client=state.mongo_client, redis_client=state.redis_client)
     logging.info("Delivery service shut down.")

--- a/delivery/src/main.py
+++ b/delivery/src/main.py
@@ -2,7 +2,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_client import make_asgi_app
+from shared.http_metrics import PrometheusMiddleware
 
 from src.lifespan import startup, teardown
 from src.routes import router
@@ -25,4 +26,6 @@ app = FastAPI(
 
 app.include_router(router)
 
-Instrumentator().instrument(app).expose(app, endpoint="/metrics")
+app.mount("/metrics", make_asgi_app())
+
+app.add_middleware(PrometheusMiddleware)  # ty: ignore[invalid-argument-type]

--- a/delivery/src/routes.py
+++ b/delivery/src/routes.py
@@ -10,7 +10,8 @@ async def liveness() -> Response:
 
 @router.get("/health/readiness")
 async def readiness(request: Request) -> Response:
-    if not getattr(request.app.state, "ready", False):
+    ctx = getattr(request.app.state, "ctx", None)
+    if not ctx or not ctx.ready:
         return Response(
             content='{"status":"not ready"}',
             media_type="application/json",

--- a/delivery/src/state.py
+++ b/delivery/src/state.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass, field
+
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
+from redis.asyncio import Redis
+from shared.redis.event_bus import EventBus
+
+from src.repository import DeliveryRepository
+from src.service import DeliveryService
+
+
+@dataclass
+class AppState:
+    mongo_client: AsyncMongoClient
+    database: AsyncDatabase
+    redis_client: Redis
+    delivery_repo: DeliveryRepository
+    delivery_service: DeliveryService
+    event_bus: EventBus | None = field(default=None)
+    ready: bool = field(default=False)

--- a/delivery/src/streams.py
+++ b/delivery/src/streams.py
@@ -1,8 +1,8 @@
-from fastapi import FastAPI
 from pydantic import BaseModel
 from shared.redis.event_bus import EventBus
 
 from src.settings import settings
+from src.state import AppState
 
 
 class OrderEvent(BaseModel):
@@ -17,15 +17,14 @@ class DeliveryStatusEvent(BaseModel):
     status: str
 
 
-async def setup_streams(app: FastAPI) -> None:
-    service = app.state.delivery_service
-    bus = EventBus(app.state.redis_client, group=settings.delivery_group)
-    bus.subscribe(settings.orders_stream, OrderEvent, service.handle_order)
-    bus.subscribe(settings.delivery_status_stream, DeliveryStatusEvent, service.handle_status_update)
+async def setup_streams(state: AppState) -> None:
+    bus = EventBus(state.redis_client, group=settings.delivery_group)
+    bus.subscribe(settings.orders_stream, OrderEvent, state.delivery_service.handle_order)
+    bus.subscribe(settings.delivery_status_stream, DeliveryStatusEvent, state.delivery_service.handle_status_update)
     await bus.start()
-    app.state.event_bus = bus
+    state.event_bus = bus
 
 
-async def stop_streams(app: FastAPI) -> None:
-    if bus := getattr(app.state, "event_bus", None):
-        await bus.stop()
+async def stop_streams(state: AppState) -> None:
+    if state.event_bus:
+        await state.event_bus.stop()

--- a/delivery/tests/test_delivery_service.py
+++ b/delivery/tests/test_delivery_service.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.schemas import DeliverySchema, DeliveryStatus
+from src.service import DeliveryService
+from src.streams import OrderEvent
+
+
+@pytest.fixture
+def delivery_repo():
+    return AsyncMock()
+
+
+@pytest.fixture
+def publisher():
+    return AsyncMock()
+
+
+@pytest.fixture
+def service(delivery_repo, publisher):
+    return DeliveryService(repo=delivery_repo, publisher=publisher)
+
+
+@pytest.mark.asyncio
+async def test_handle_order_creates_delivery(service, delivery_repo, publisher):
+    delivery_repo.create.return_value = "del123"
+    msg = OrderEvent(id="order123", status="out_for_delivery", simulation=1)
+
+    await service.handle_order(msg)
+
+    delivery_repo.create.assert_called_once()
+    assert publisher.publish_raw.call_count == 2  # deliveries_stream + simulate_delivery_stream
+
+
+@pytest.mark.asyncio
+async def test_handle_order_skips_non_delivery_status(service, delivery_repo, publisher):
+    msg = SimpleNamespace(id="order123", status="confirmed", simulation=1)
+
+    await service.handle_order(msg)
+
+    delivery_repo.create.assert_not_called()
+    publisher.publish_raw.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_order_no_simulation(service, delivery_repo, publisher):
+    delivery_repo.create.return_value = "del123"
+    msg = OrderEvent(id="order123", status="out_for_delivery", simulation=-1)
+
+    await service.handle_order(msg)
+
+    delivery_repo.create.assert_called_once()
+    assert publisher.publish_raw.call_count == 1  # only deliveries_stream, no simulate
+
+
+@pytest.mark.asyncio
+async def test_handle_status_update_success(service, delivery_repo, publisher):
+    delivery = DeliverySchema(order_id="order123")
+    delivery.id = "del123"
+    delivery_repo.find_one.return_value = delivery
+    delivery_repo.update_status.return_value = True
+
+    msg = SimpleNamespace(id=None, order_id="order123", status="on_the_way")
+
+    await service.handle_status_update(msg)
+
+    delivery_repo.update_status.assert_called_once_with("del123", DeliveryStatus.ON_THE_WAY)
+    publisher.publish_raw.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_status_update_delivery_not_found(service, delivery_repo):
+    delivery_repo.find_one.return_value = None
+    msg = SimpleNamespace(id=None, order_id="order123", status="on_the_way")
+
+    with pytest.raises(ValueError, match="Delivery not found"):
+        await service.handle_status_update(msg)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -273,6 +273,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_SERVER_ROOT_URL=http://localhost/grafana/
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
     volumes:
       - ./monitoring/grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
       - grafana_data:/var/lib/grafana

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Link } from '@tanstack/react-router';
-import { ShoppingCart } from 'lucide-react';
+import { ShoppingCart, Wrench } from 'lucide-react';
 import { ModeToggle } from './mode-toggle';
 
 const Layout = ({ children }: { children?: ReactNode }) => {
@@ -12,6 +12,9 @@ const Layout = ({ children }: { children?: ReactNode }) => {
         </h1>
         <div className="flex items-center gap-4">
           <ModeToggle />
+          <Link to="/dev">
+            <Wrench className="h-5 w-5 hover:text-blue-500 transition" />
+          </Link>
           <Link to="/cart">
             <ShoppingCart className="h-6 w-6 hover:text-blue-500 transition" />
           </Link>

--- a/frontend/src/pages/DevTools.tsx
+++ b/frontend/src/pages/DevTools.tsx
@@ -1,0 +1,90 @@
+import { ExternalLink } from 'lucide-react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/components/ui/card';
+
+const tools = [
+  {
+    title: 'Grafana',
+    description: 'Dashboards, metrics visualization & logs explorer',
+    url: '/grafana/',
+    credentials: 'admin / admin',
+  },
+  {
+    title: 'Prometheus',
+    description: 'Metrics collection, PromQL queries & targets',
+    url: 'http://localhost:9090',
+  },
+  {
+    title: 'Order Service — API Docs',
+    description: 'OpenAPI / Swagger UI for orders & menu endpoints',
+    url: 'http://localhost:8003/docs',
+  },
+  {
+    title: 'Delivery Service — API Docs',
+    description: 'OpenAPI / Swagger UI for delivery endpoints',
+    url: 'http://localhost:8001/docs',
+  },
+  {
+    title: 'Notifications Service — API Docs',
+    description: 'OpenAPI / Swagger UI for notifications endpoints',
+    url: 'http://localhost:8002/docs',
+  },
+  {
+    title: 'Order Service — Metrics',
+    description: 'Raw Prometheus metrics from the order service',
+    url: 'http://localhost:8003/metrics',
+  },
+  {
+    title: 'Delivery Service — Metrics',
+    description: 'Raw Prometheus metrics from the delivery service',
+    url: 'http://localhost:8001/metrics',
+  },
+  {
+    title: 'Notifications Service — Metrics',
+    description: 'Raw Prometheus metrics from the notifications service',
+    url: 'http://localhost:8002/metrics',
+  },
+];
+
+const DevTools = () => {
+  return (
+    <div className="max-w-5xl mx-auto">
+      <h2 className="text-2xl font-bold mb-6">Dev Tools</h2>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {tools.map((tool) => (
+          <a
+            key={tool.title}
+            href={tool.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block hover:ring-2 hover:ring-blue-500 rounded-xl transition"
+          >
+            <Card className="h-full">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  {tool.title}
+                  <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                </CardTitle>
+                <CardDescription>{tool.description}</CardDescription>
+              </CardHeader>
+              {tool.credentials && (
+                <CardContent>
+                  <code className="text-xs bg-muted px-2 py-1 rounded">
+                    {tool.credentials}
+                  </code>
+                </CardContent>
+              )}
+            </Card>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DevTools;

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -4,6 +4,7 @@ import MenuPage from '@/pages/Menu';
 import OrderPage from '@/pages/Order';
 import CartPage from '@/pages/Cart.tsx';
 import OrderTracking from '@/pages/OrderTracking.tsx';
+import DevTools from '@/pages/DevTools.tsx';
 
 const rootRoute = createRootRoute({
   component: () => (
@@ -37,6 +38,12 @@ const trackerRoute = createRoute({
   component: OrderTracking,
 });
 
-rootRoute.addChildren([menuRoute, cartRoute, orderRoute, trackerRoute]);
+const devToolsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/dev',
+  component: DevTools,
+});
+
+rootRoute.addChildren([menuRoute, cartRoute, orderRoute, trackerRoute, devToolsRoute]);
 
 export const routeTree = rootRoute;

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -44,6 +44,12 @@ const devToolsRoute = createRoute({
   component: DevTools,
 });
 
-rootRoute.addChildren([menuRoute, cartRoute, orderRoute, trackerRoute, devToolsRoute]);
+rootRoute.addChildren([
+  menuRoute,
+  cartRoute,
+  orderRoute,
+  trackerRoute,
+  devToolsRoute,
+]);
 
 export const routeTree = rootRoute;

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -10,6 +10,10 @@ upstream frontend_app {
     server frontend:3000;
 }
 
+upstream grafana {
+    server grafana:3000;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -47,6 +51,20 @@ server {
 
     location /api/v1/health {
         proxy_pass http://orders_api;
+    }
+
+    # Grafana (reverse-proxied under /grafana/)
+    location /grafana/ {
+        proxy_pass http://grafana;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support for Grafana Live
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 
     # WebSocket - Order Tracking

--- a/notifications/pyproject.toml
+++ b/notifications/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
 dev = [
     "ty>=0.0.1a7",
     "ruff==0.11.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
 ]
 
 [tool.uv.sources]

--- a/notifications/pytest.ini
+++ b/notifications/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+pythonpath = .

--- a/notifications/src/lifespan.py
+++ b/notifications/src/lifespan.py
@@ -7,27 +7,35 @@ from shared.redis.connection import connect_redis
 from src.repository import NotificationRepository
 from src.service import NotificationService
 from src.settings import settings
+from src.state import AppState
 from src.streams import setup_streams, stop_streams
 from src.websockets import ws_order_status_manager
 
 
 async def startup(app: FastAPI) -> None:
-    app.state.ready = False
     setup_logging()
+    redis_client = await connect_redis(settings.redis_url)
 
-    app.state.redis_client = await connect_redis(settings.redis_url)
+    notification_repo = NotificationRepository(redis_client)
 
-    app.state.notification_repository = NotificationRepository(app.state.redis_client)
-    app.state.notification_service = NotificationService(app.state.notification_repository, ws_order_status_manager)
+    state = AppState(
+        redis_client=redis_client,
+        notification_repository=notification_repo,
+        notification_service=NotificationService(notification_repo, ws_order_status_manager),
+    )
 
-    await setup_streams(app)
-    app.state.ready = True
+    await setup_streams(state)
+    state.ready = True
+    app.state.ctx = state
     logging.info("Notification service is ready.")
 
 
 async def teardown(app: FastAPI) -> None:
-    app.state.ready = False
-    await stop_streams(app)
-    if redis := getattr(app.state, "redis_client", None):
-        await redis.close()
+    state: AppState | None = getattr(app.state, "ctx", None)
+    if not state:
+        return
+    state.ready = False
+    await stop_streams(state)
+    if state.redis_client:
+        await state.redis_client.close()
     logging.info("Notification service shut down.")

--- a/notifications/src/main.py
+++ b/notifications/src/main.py
@@ -6,11 +6,13 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_client import make_asgi_app
+from shared.http_metrics import PrometheusMiddleware
 
 from src.lifespan import startup, teardown
 from src.routes import router
 from src.settings import settings
+from src.state import AppState
 from src.websockets import ws_order_status_manager
 
 
@@ -36,7 +38,8 @@ app: FastAPI = FastAPI(
 @app.websocket("/ws/v1/order-tracking/{order_id}")
 async def websocket_order_tracking(websocket: WebSocket, order_id: str) -> None:
     await ws_order_status_manager.connect(order_id, websocket)
-    notifications_repo = app.state.notification_repository
+    state: AppState = app.state.ctx
+    notifications_repo = state.notification_repository
 
     if status := await notifications_repo.get_order_status(order_id):
         try:
@@ -64,8 +67,9 @@ async def websocket_order_tracking(websocket: WebSocket, order_id: str) -> None:
 
 app.include_router(router)
 
-Instrumentator().instrument(app).expose(app, endpoint="/metrics")
+app.mount("/metrics", make_asgi_app())
 
+app.add_middleware(PrometheusMiddleware)  # ty: ignore[invalid-argument-type]
 app.add_middleware(GZipMiddleware)  # ty: ignore[invalid-argument-type]
 app.add_middleware(
     CORSMiddleware,  # ty: ignore[invalid-argument-type]

--- a/notifications/src/routes.py
+++ b/notifications/src/routes.py
@@ -10,7 +10,8 @@ async def liveness() -> Response:
 
 @router.get("/health/readiness")
 async def readiness(request: Request) -> Response:
-    if not getattr(request.app.state, "ready", False):
+    ctx = getattr(request.app.state, "ctx", None)
+    if not ctx or not ctx.ready:
         return Response(
             content='{"status":"not ready"}',
             media_type="application/json",

--- a/notifications/src/state.py
+++ b/notifications/src/state.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+
+from redis.asyncio import Redis
+from shared.redis.event_bus import EventBus
+
+from src.repository import NotificationRepository
+from src.service import NotificationService
+
+
+@dataclass
+class AppState:
+    redis_client: Redis
+    notification_repository: NotificationRepository
+    notification_service: NotificationService
+    event_bus: EventBus | None = field(default=None)
+    ready: bool = field(default=False)

--- a/notifications/src/streams.py
+++ b/notifications/src/streams.py
@@ -1,8 +1,8 @@
-from fastapi import FastAPI
 from pydantic import BaseModel
 from shared.redis.event_bus import EventBus
 
 from src.settings import settings
+from src.state import AppState
 
 
 class EventMessage(BaseModel):
@@ -11,15 +11,14 @@ class EventMessage(BaseModel):
     status: str | None = None
 
 
-async def setup_streams(app: FastAPI) -> None:
-    service = app.state.notification_service
-    bus = EventBus(app.state.redis_client, group=settings.notifications_group)
-    bus.subscribe(settings.orders_stream, EventMessage, service.handle_event)
-    bus.subscribe(settings.deliveries_stream, EventMessage, service.handle_event)
+async def setup_streams(state: AppState) -> None:
+    bus = EventBus(state.redis_client, group=settings.notifications_group)
+    bus.subscribe(settings.orders_stream, EventMessage, state.notification_service.handle_event)
+    bus.subscribe(settings.deliveries_stream, EventMessage, state.notification_service.handle_event)
     await bus.start()
-    app.state.event_bus = bus
+    state.event_bus = bus
 
 
-async def stop_streams(app: FastAPI) -> None:
-    if bus := getattr(app.state, "event_bus", None):
-        await bus.stop()
+async def stop_streams(state: AppState) -> None:
+    if state.event_bus:
+        await state.event_bus.stop()

--- a/notifications/tests/test_notification_service.py
+++ b/notifications/tests/test_notification_service.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.service import NotificationService
+
+
+@pytest.fixture
+def notification_repo():
+    return AsyncMock()
+
+
+@pytest.fixture
+def ws_manager():
+    return AsyncMock()
+
+
+@pytest.fixture
+def service(notification_repo, ws_manager):
+    return NotificationService(repo=notification_repo, ws_manager=ws_manager)
+
+
+@pytest.mark.asyncio
+async def test_handle_event_broadcasts_and_caches(service, notification_repo, ws_manager):
+    msg = SimpleNamespace(order_id="order123", id=None, status="preparing")
+
+    await service.handle_event(msg)
+
+    ws_manager.broadcast.assert_called_once()
+    call_args = ws_manager.broadcast.call_args
+    assert call_args[0][0] == "order123"
+    assert call_args[0][1]["status"] == "preparing"
+
+    notification_repo.set_order_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_uses_id_as_fallback(service, ws_manager, notification_repo):
+    msg = SimpleNamespace(order_id=None, id="order456", status="confirmed")
+
+    await service.handle_event(msg)
+
+    ws_manager.broadcast.assert_called_once()
+    call_args = ws_manager.broadcast.call_args
+    assert call_args[0][0] == "order456"
+
+
+@pytest.mark.asyncio
+async def test_handle_event_missing_data_raises(service):
+    msg = SimpleNamespace(order_id=None, id=None, status=None)
+
+    with pytest.raises(ValueError, match="Invalid data"):
+        await service.handle_event(msg)

--- a/orders/pyproject.toml
+++ b/orders/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
 dev = [
     "ty>=0.0.1a7",
     "ruff==0.11.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
 ]
 
 [tool.uv.sources]

--- a/orders/pytest.ini
+++ b/orders/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+pythonpath = .

--- a/orders/src/databases.py
+++ b/orders/src/databases.py
@@ -1,20 +1,20 @@
-from fastapi import FastAPI
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
+from redis.asyncio import Redis
 from shared.db.mongo import connect_mongo
 from shared.redis.connection import connect_redis
 
 from src.settings import settings
 
 
-async def setup_databases(app: FastAPI) -> None:
-    app.state.mongo_client, app.state.database = await connect_mongo(settings.mongo_url, settings.mongo_db)
-    app.state.redis_client = await connect_redis(settings.redis_url)
+async def connect_databases() -> tuple[AsyncMongoClient, AsyncDatabase, Redis]:
+    mongo_client, database = await connect_mongo(settings.mongo_url, settings.mongo_db)
+    redis_client = await connect_redis(settings.redis_url)
+    return mongo_client, database, redis_client
 
 
-async def close_databases(app: FastAPI) -> None:
-    if redis := getattr(app.state, "redis_client", None):
-        await redis.close()
-    if mongo := getattr(app.state, "mongo_client", None):
-        await mongo.close()
-
-
-__all__ = ["setup_databases", "close_databases"]
+async def close_databases(*, mongo_client: AsyncMongoClient | None = None, redis_client: Redis | None = None) -> None:
+    if redis_client:
+        await redis_client.close()
+    if mongo_client:
+        await mongo_client.close()

--- a/orders/src/dependencies.py
+++ b/orders/src/dependencies.py
@@ -2,11 +2,16 @@ from fastapi import Request
 
 from src.services.menu_service import MenuService
 from src.services.order_service import OrderService
+from src.state import AppState
+
+
+def get_app_state(request: Request) -> AppState:
+    return request.app.state.ctx
 
 
 def get_menu_service(request: Request) -> MenuService:
-    return request.app.state.menu_service
+    return get_app_state(request).menu_service
 
 
 def get_order_service(request: Request) -> OrderService:
-    return request.app.state.order_service
+    return get_app_state(request).order_service

--- a/orders/src/lifespan.py
+++ b/orders/src/lifespan.py
@@ -5,43 +5,55 @@ from fastapi import FastAPI
 from shared.logging import setup_logging
 from shared.redis.publisher import StreamProducer
 
-from src.databases import close_databases, setup_databases
+from src.databases import close_databases, connect_databases
 from src.repositories.menu_item_repo import MenuItemRepository
 from src.repositories.order_repository import OrderRepository
 from src.services.menu_service import MenuService
 from src.services.order_service import OrderService
 from src.settings import settings
+from src.state import AppState
 from src.streams import setup_streams, stop_streams
 
 
 async def startup(app: FastAPI) -> None:
-    app.state.ready = False
     setup_logging()
-    await setup_databases(app)
+    mongo_client, database, redis_client = await connect_databases()
 
-    app.state.menu_repository = MenuItemRepository(
-        collection=app.state.database.get_collection(settings.mongo_collection_menu_items),
+    menu_repo = MenuItemRepository(
+        collection=database.get_collection(settings.mongo_collection_menu_items),
     )
-    app.state.order_repository = OrderRepository(
-        collection=app.state.database.get_collection(settings.mongo_collection_orders),
-    )
-
-    publisher: StreamProducer[Any] = StreamProducer(app.state.redis_client, source="orders-service")
-    app.state.menu_service = MenuService(repo=app.state.menu_repository, mongo_client=app.state.mongo_client)
-    app.state.order_service = OrderService(
-        order_repo=app.state.order_repository,
-        menu_repo=app.state.menu_repository,
-        publisher=publisher,
-        mongo_client=app.state.mongo_client,
+    order_repo = OrderRepository(
+        collection=database.get_collection(settings.mongo_collection_orders),
     )
 
-    await setup_streams(app)
-    app.state.ready = True
+    publisher: StreamProducer[Any] = StreamProducer(redis_client, source="orders-service")
+
+    state = AppState(
+        mongo_client=mongo_client,
+        database=database,
+        redis_client=redis_client,
+        menu_repository=menu_repo,
+        order_repository=order_repo,
+        menu_service=MenuService(repo=menu_repo, mongo_client=mongo_client),
+        order_service=OrderService(
+            order_repo=order_repo,
+            menu_repo=menu_repo,
+            publisher=publisher,
+            mongo_client=mongo_client,
+        ),
+    )
+
+    await setup_streams(state)
+    state.ready = True
+    app.state.ctx = state
     logging.info("Orders service is ready.")
 
 
 async def teardown(app: FastAPI) -> None:
-    app.state.ready = False
-    await stop_streams(app)
-    await close_databases(app)
+    state: AppState | None = getattr(app.state, "ctx", None)
+    if not state:
+        return
+    state.ready = False
+    await stop_streams(state)
+    await close_databases(mongo_client=state.mongo_client, redis_client=state.redis_client)
     logging.info("Orders service is shut down.")

--- a/orders/src/main.py
+++ b/orders/src/main.py
@@ -4,7 +4,8 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_client import make_asgi_app
+from shared.http_metrics import PrometheusMiddleware
 
 from src.lifespan import startup, teardown
 from src.routes import router
@@ -31,8 +32,9 @@ app: FastAPI = FastAPI(
 
 app.include_router(router)
 
-Instrumentator().instrument(app).expose(app, endpoint="/metrics")
+app.mount("/metrics", make_asgi_app())
 
+app.add_middleware(PrometheusMiddleware)  # ty: ignore[invalid-argument-type]
 app.add_middleware(GZipMiddleware)  # ty: ignore[invalid-argument-type]
 app.add_middleware(
     CORSMiddleware,  # ty: ignore[invalid-argument-type]

--- a/orders/src/routes/health.py
+++ b/orders/src/routes/health.py
@@ -10,7 +10,8 @@ async def liveness() -> Response:
 
 @router.get("/readiness")
 async def readiness(request: Request) -> Response:
-    if not getattr(request.app.state, "ready", False):
+    ctx = getattr(request.app.state, "ctx", None)
+    if not ctx or not ctx.ready:
         return Response(
             content='{"status":"not ready"}',
             media_type="application/json",

--- a/orders/src/state.py
+++ b/orders/src/state.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
+from redis.asyncio import Redis
+from shared.redis.event_bus import EventBus
+
+from src.repositories.menu_item_repo import MenuItemRepository
+from src.repositories.order_repository import OrderRepository
+from src.services.menu_service import MenuService
+from src.services.order_service import OrderService
+
+
+@dataclass
+class AppState:
+    mongo_client: AsyncMongoClient
+    database: AsyncDatabase
+    redis_client: Redis
+    menu_repository: MenuItemRepository
+    order_repository: OrderRepository
+    menu_service: MenuService
+    order_service: OrderService
+    event_bus: EventBus | None = field(default=None)
+    ready: bool = field(default=False)

--- a/orders/src/streams.py
+++ b/orders/src/streams.py
@@ -1,8 +1,8 @@
-from fastapi import FastAPI
 from pydantic import BaseModel
 from shared.redis.event_bus import EventBus
 
 from src.settings import settings
+from src.state import AppState
 
 
 class StatusUpdateMessage(BaseModel):
@@ -10,13 +10,13 @@ class StatusUpdateMessage(BaseModel):
     status: str
 
 
-async def setup_streams(app: FastAPI) -> None:
-    bus = EventBus(app.state.redis_client, group=settings.orders_group)
-    bus.subscribe(settings.order_status_stream, StatusUpdateMessage, app.state.order_service.handle_status_update)
+async def setup_streams(state: AppState) -> None:
+    bus = EventBus(state.redis_client, group=settings.orders_group)
+    bus.subscribe(settings.order_status_stream, StatusUpdateMessage, state.order_service.handle_status_update)
     await bus.start()
-    app.state.event_bus = bus
+    state.event_bus = bus
 
 
-async def stop_streams(app: FastAPI) -> None:
-    if bus := getattr(app.state, "event_bus", None):
-        await bus.stop()
+async def stop_streams(state: AppState) -> None:
+    if state.event_bus:
+        await state.event_bus.stop()

--- a/orders/tests/test_menu_service.py
+++ b/orders/tests/test_menu_service.py
@@ -28,9 +28,12 @@ def service(menu_repo, mongo_client):
 
 
 def _make_item(**overrides):
-    defaults = {"name": "Burger", "price": 9.99, "category": "food", "stock": 10}
-    defaults.update(overrides)
-    return MenuItemSchema(**defaults)
+    return MenuItemSchema(
+        name=overrides.get("name", "Burger"),
+        price=overrides.get("price", 9.99),
+        category=overrides.get("category", "food"),
+        stock=overrides.get("stock", 10),
+    )
 
 
 @pytest.mark.asyncio

--- a/orders/tests/test_menu_service.py
+++ b/orders/tests/test_menu_service.py
@@ -1,0 +1,74 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.schemas import MenuItemSchema
+from src.services.menu_service import MenuService
+
+
+@pytest.fixture
+def menu_repo():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mongo_client():
+    client = MagicMock()
+    session = AsyncMock()
+    client.start_session.return_value = session
+    session.start_transaction = AsyncMock()
+    session.commit_transaction = AsyncMock()
+    session.end_session = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def service(menu_repo, mongo_client):
+    return MenuService(repo=menu_repo, mongo_client=mongo_client)
+
+
+def _make_item(**overrides):
+    defaults = {"name": "Burger", "price": 9.99, "category": "food", "stock": 10}
+    defaults.update(overrides)
+    return MenuItemSchema(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_get_item(service, menu_repo):
+    item = _make_item()
+    menu_repo.get_by_id.return_value = item
+
+    result = await service.get_item("item123")
+
+    assert result == item
+    menu_repo.get_by_id.assert_called_once_with("item123", session=None)
+
+
+@pytest.mark.asyncio
+async def test_get_item_not_found(service, menu_repo):
+    menu_repo.get_by_id.return_value = None
+
+    result = await service.get_item("missing")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_list_items(service, menu_repo):
+    items = [_make_item(name="Burger"), _make_item(name="Pizza")]
+    menu_repo.find_many.return_value = items
+
+    result = await service.list_items()
+
+    assert len(result) == 2
+    menu_repo.find_many.assert_called_once_with({}, session=None)
+
+
+@pytest.mark.asyncio
+async def test_create_item(service, menu_repo):
+    menu_repo.create.return_value = "newid"
+    item = _make_item()
+
+    result = await service.create_item(item)
+
+    assert result == "newid"

--- a/orders/tests/test_order_service.py
+++ b/orders/tests/test_order_service.py
@@ -1,0 +1,116 @@
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.schemas import MenuItemSchema, OrderSchema, OrderStatus, OrderedItemSchema, OrderingPersonSchema
+from src.services.order_service import OrderService
+
+
+@pytest.fixture
+def order_repo():
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def menu_repo():
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def publisher():
+    pub = AsyncMock()
+    return pub
+
+
+@pytest.fixture
+def mongo_client():
+    client = MagicMock()
+    session = AsyncMock()
+    client.start_session.return_value = session
+    session.start_transaction = AsyncMock()
+    session.commit_transaction = AsyncMock()
+    session.abort_transaction = AsyncMock()
+    session.end_session = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def service(order_repo, menu_repo, publisher, mongo_client):
+    return OrderService(
+        order_repo=order_repo,
+        menu_repo=menu_repo,
+        publisher=publisher,
+        mongo_client=mongo_client,
+    )
+
+
+def _make_order(**overrides):
+    defaults = {
+        "person": OrderingPersonSchema(
+            first_name="John", last_name="Doe", address="123 Main St", phone_number="555-1234"
+        ),
+        "items": [OrderedItemSchema(item_id="507f1f77bcf86cd799439011", quantity=2)],
+    }
+    defaults.update(overrides)
+    return OrderSchema(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_create_order_success(service, menu_repo, order_repo, publisher):
+    menu_item = MenuItemSchema(
+        name="Burger", price=9.99, category="food", stock=10, id="507f1f77bcf86cd799439011"
+    )
+    menu_repo.get_by_id.return_value = menu_item
+    menu_repo.decrement_stock.return_value = True
+    order_repo.create.return_value = "order123"
+
+    order = _make_order()
+    result = await service.create_order_with_stock_check(order)
+
+    assert result.success is True
+    assert order.total_price == Decimal("19.98")
+    assert order.id == "order123"
+    publisher.publish_raw.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_create_order_item_not_found(service, menu_repo):
+    menu_repo.get_by_id.return_value = None
+
+    order = _make_order()
+    result = await service.create_order_with_stock_check(order)
+
+    assert result.success is False
+    assert "not found" in result.message
+
+
+@pytest.mark.asyncio
+async def test_create_order_insufficient_stock(service, menu_repo):
+    menu_item = MenuItemSchema(
+        name="Burger", price=9.99, category="food", stock=1, id="507f1f77bcf86cd799439011"
+    )
+    menu_repo.get_by_id.return_value = menu_item
+    menu_repo.decrement_stock.return_value = False
+
+    order = _make_order()
+    result = await service.create_order_with_stock_check(order)
+
+    assert result.success is False
+    assert "stock" in result.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_status_update(service, order_repo, publisher):
+    order_repo.update_status.return_value = True
+    msg = SimpleNamespace(id="order123", status="preparing")
+
+    await service.handle_status_update(msg)
+
+    publisher.publish_raw.assert_called_once()
+    call_kwargs = publisher.publish_raw.call_args
+    assert call_kwargs.kwargs["event_type"] == "order.status_updated"
+    assert call_kwargs.kwargs["correlation_id"] == "order123"

--- a/orders/tests/test_order_service.py
+++ b/orders/tests/test_order_service.py
@@ -49,14 +49,17 @@ def service(order_repo, menu_repo, publisher, mongo_client):
 
 
 def _make_order(**overrides):
-    defaults = {
-        "person": OrderingPersonSchema(
-            first_name="John", last_name="Doe", address="123 Main St", phone_number="555-1234"
+    return OrderSchema(
+        person=overrides.get(
+            "person",
+            OrderingPersonSchema(
+                first_name="John", last_name="Doe", address="123 Main St", phone_number="555-1234"
+            ),
         ),
-        "items": [OrderedItemSchema(item_id="507f1f77bcf86cd799439011", quantity=2)],
-    }
-    defaults.update(overrides)
-    return OrderSchema(**defaults)
+        items=overrides.get(
+            "items", [OrderedItemSchema(item_id="507f1f77bcf86cd799439011", quantity=2)]
+        ),
+    )
 
 
 @pytest.mark.asyncio

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pydantic>=2.8",
     "pydantic-settings>=2.8",
     "prometheus-client>=0.21",
-    "prometheus-fastapi-instrumentator>=7.0",
+    "starlette>=0.36",
 ]
 
 [dependency-groups]

--- a/shared/src/shared/http_metrics.py
+++ b/shared/src/shared/http_metrics.py
@@ -1,0 +1,47 @@
+import time
+from collections.abc import MutableMapping
+from typing import Any
+
+from prometheus_client import Counter, Histogram
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status_code"],
+)
+
+HTTP_REQUEST_DURATION = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "path"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+)
+
+
+class PrometheusMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope.get("path") == "/metrics":
+            await self.app(scope, receive, send)
+            return
+
+        method: str = scope.get("method", "GET")
+        path: str = scope.get("path", "")
+        start = time.perf_counter()
+        status_code = 500
+
+        async def send_wrapper(message: MutableMapping[str, Any]) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            duration = time.perf_counter() - start
+            HTTP_REQUESTS_TOTAL.labels(method, path, str(status_code)).inc()
+            HTTP_REQUEST_DURATION.labels(method, path).observe(duration)

--- a/uv.lock
+++ b/uv.lock
@@ -90,6 +90,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -105,6 +107,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = "==0.11.0" },
     { name = "ty", specifier = ">=0.0.1a7" },
 ]
@@ -342,6 +346,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -439,6 +452,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -453,6 +468,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = "==0.11.0" },
     { name = "ty", specifier = ">=0.0.1a7" },
 ]
@@ -471,6 +488,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -486,6 +505,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = "==0.11.0" },
     { name = "ty", specifier = ">=0.0.1a7" },
 ]
@@ -510,25 +531,30 @@ dev = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
-]
-
-[[package]]
-name = "prometheus-fastapi-instrumentator"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "prometheus-client" },
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
 ]
 
 [[package]]
@@ -637,6 +663,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c7/b5337093bb01da852f945802328665f85f8109dbe91d81ea2afe5ff059b9/pymongo-4.16.0-cp314-cp314t-win32.whl", hash = "sha256:948152b30eddeae8355495f9943a3bf66b708295c0b9b6f467de1c620f215487", size = 1040560, upload-time = "2026-01-07T18:05:23.888Z" },
     { url = "https://files.pythonhosted.org/packages/96/8c/5b448cd1b103f3889d5713dda37304c81020ff88e38a826e8a75ddff4610/pymongo-4.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f6e42c1bc985d9beee884780ae6048790eb4cd565c46251932906bdb1630034a", size = 1075081, upload-time = "2026-01-07T18:05:26.874Z" },
     { url = "https://files.pythonhosted.org/packages/32/cd/ddc794cdc8500f6f28c119c624252fb6dfb19481c6d7ed150f13cf468a6d/pymongo-4.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6b2a20edb5452ac8daa395890eeb076c570790dfce6b7a44d788af74c2f8cf96", size = 1047725, upload-time = "2026-01-07T18:05:28.47Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -826,11 +880,11 @@ version = "0.1.0"
 source = { editable = "shared" }
 dependencies = [
     { name = "prometheus-client" },
-    { name = "prometheus-fastapi-instrumentator" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pymongo" },
     { name = "redis" },
+    { name = "starlette" },
 ]
 
 [package.dev-dependencies]
@@ -842,11 +896,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "prometheus-client", specifier = ">=0.21" },
-    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0" },
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pydantic-settings", specifier = ">=2.8" },
     { name = "pymongo", specifier = ">=4.10" },
     { name = "redis", specifier = ">=5.2" },
+    { name = "starlette", specifier = ">=0.36" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Replace `prometheus-fastapi-instrumentator` with custom `PrometheusMiddleware` using official `prometheus_client`
- Introduce typed `AppState` dataclass per service (stored as `app.state.ctx`)
- Add unit tests for orders (menu + order services) and delivery service
- Add full monitoring stack: Prometheus, Grafana, Loki + Promtail configs
- Add Helm ServiceMonitor templates for all services
- Proxy Grafana through nginx at `/grafana/`
- Add frontend Dev Tools page (`/dev`) with links to Grafana, Prometheus, API docs, and metrics
- Update README with monitoring section, quick links table, and project structure

## Test plan
- [ ] `uv run ruff check` passes on all services
- [ ] `uv run ty check` passes on all services (including tests/)
- [ ] `uv run pytest` passes for orders, delivery, notifications
- [ ] `docker compose up --build` starts all services + monitoring stack
- [ ] Grafana accessible at `http://localhost/grafana/` with admin/admin
- [ ] Dev Tools page renders at `http://localhost/dev` with working links
- [ ] Service `/docs` and `/metrics` endpoints accessible