### PR TITLE
OP010: Monitoring dashboards, read-only Prometheus proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The project includes a full observability stack:
 | Frontend                    | http://localhost                      | —               |
 | Dev Tools page              | http://localhost/dev                  | —               |
 | Grafana                     | http://localhost/grafana/             | admin / admin   |
-| Prometheus                  | http://localhost:9090                 | —               |
+| Prometheus (read-only)      | http://localhost/prometheus/          | —               |
 | Order Service — API Docs    | http://localhost:8003/docs            | —               |
 | Delivery Service — API Docs | http://localhost:8001/docs            | —               |
 | Notifications — API Docs    | http://localhost:8002/docs            | —               |

--- a/README.md
+++ b/README.md
@@ -183,15 +183,19 @@ The project includes a full observability stack:
 
 ### Quick Links (Docker Compose)
 
-| Tool                        | URL                                  | Credentials     |
-|-----------------------------|--------------------------------------|-----------------|
-| Frontend                    | http://localhost                      | —               |
-| Dev Tools page              | http://localhost/dev                  | —               |
-| Grafana                     | http://localhost/grafana/             | admin / admin   |
-| Prometheus (read-only)      | http://localhost/prometheus/          | —               |
-| Order Service — API Docs    | http://localhost:8003/docs            | —               |
-| Delivery Service — API Docs | http://localhost:8001/docs            | —               |
-| Notifications — API Docs    | http://localhost:8002/docs            | —               |
+| Tool                        | URL                                          | Credentials     |
+|-----------------------------|----------------------------------------------|-----------------|
+| Frontend                    | http://localhost                               | —               |
+| Dev Tools page              | http://localhost/dev                           | —               |
+| Grafana (admin)             | http://localhost/grafana/                      | admin / admin   |
+| HTTP Metrics dashboard      | http://localhost/grafana/d/http-metrics        | — (read-only)   |
+| Application Logs dashboard  | http://localhost/grafana/d/application-logs    | — (read-only)   |
+| Prometheus (read-only)      | http://localhost/prometheus/                   | —               |
+| Order Service — API Docs    | http://localhost:8003/docs                     | —               |
+| Delivery Service — API Docs | http://localhost:8001/docs                     | —               |
+| Notifications — API Docs    | http://localhost:8002/docs                     | —               |
+
+Grafana dashboards are accessible without login (anonymous viewer role). Admin access requires credentials above.
 
 All service OpenAPI docs are available only in `DEVELOPMENT` environment.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -228,8 +228,11 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
-    ports:
-      - "9090:9090"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.external-url=http://localhost/prometheus/"
+      - "--web.route-prefix=/"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -280,6 +280,8 @@ services:
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
     volumes:
       - ./monitoring/grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+      - ./monitoring/grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana_data:/var/lib/grafana
     depends_on:
       - prometheus

--- a/frontend/src/pages/DevTools.tsx
+++ b/frontend/src/pages/DevTools.tsx
@@ -9,8 +9,20 @@ import {
 
 const tools = [
   {
+    title: 'Grafana — HTTP Metrics',
+    description: 'Request rate, latency percentiles & error rates',
+    url: '/grafana/d/http-metrics/http-metrics',
+    badge: 'read-only',
+  },
+  {
+    title: 'Grafana — Application Logs',
+    description: 'Live log stream, volume & error tracking (Loki)',
+    url: '/grafana/d/application-logs/application-logs',
+    badge: 'read-only',
+  },
+  {
     title: 'Grafana',
-    description: 'Dashboards, metrics visualization & logs explorer',
+    description: 'All dashboards, explore & admin',
     url: '/grafana/',
     credentials: 'admin / admin',
   },
@@ -34,21 +46,6 @@ const tools = [
     title: 'Notifications Service — API Docs',
     description: 'OpenAPI / Swagger UI for notifications endpoints',
     url: 'http://localhost:8002/docs',
-  },
-  {
-    title: 'Order Service — Metrics',
-    description: 'Raw Prometheus metrics from the order service',
-    url: 'http://localhost:8003/metrics',
-  },
-  {
-    title: 'Delivery Service — Metrics',
-    description: 'Raw Prometheus metrics from the delivery service',
-    url: 'http://localhost:8001/metrics',
-  },
-  {
-    title: 'Notifications Service — Metrics',
-    description: 'Raw Prometheus metrics from the notifications service',
-    url: 'http://localhost:8002/metrics',
   },
 ];
 

--- a/frontend/src/pages/DevTools.tsx
+++ b/frontend/src/pages/DevTools.tsx
@@ -17,7 +17,8 @@ const tools = [
   {
     title: 'Prometheus',
     description: 'Metrics collection, PromQL queries & targets',
-    url: 'http://localhost:9090',
+    url: '/prometheus/',
+    badge: 'read-only',
   },
   {
     title: 'Order Service — API Docs',
@@ -72,11 +73,18 @@ const DevTools = () => {
                 </CardTitle>
                 <CardDescription>{tool.description}</CardDescription>
               </CardHeader>
-              {tool.credentials && (
-                <CardContent>
-                  <code className="text-xs bg-muted px-2 py-1 rounded">
-                    {tool.credentials}
-                  </code>
+              {(tool.credentials || tool.badge) && (
+                <CardContent className="flex gap-2">
+                  {tool.credentials && (
+                    <code className="text-xs bg-muted px-2 py-1 rounded">
+                      {tool.credentials}
+                    </code>
+                  )}
+                  {tool.badge && (
+                    <span className="text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 px-2 py-1 rounded">
+                      {tool.badge}
+                    </span>
+                  )}
                 </CardContent>
               )}
             </Card>

--- a/monitoring/grafana/dashboards.yml
+++ b/monitoring/grafana/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: true
+    editable: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/dashboards/application-logs.json
+++ b/monitoring/grafana/dashboards/application-logs.json
@@ -1,0 +1,92 @@
+{
+  "uid": "application-logs",
+  "title": "Application Logs",
+  "tags": ["loki", "logs"],
+  "timezone": "browser",
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "" },
+        "query": "label_values(compose_service)",
+        "refresh": 2,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "search",
+        "type": "textbox",
+        "current": { "text": "", "value": "" },
+        "label": "Search"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log Volume",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({compose_service=~\"$service\"} |~ \"$search\" [1m])) by (compose_service)",
+          "legendFormat": "{{ compose_service }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "bars", "fillOpacity": 50, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Logs",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 6 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({compose_service=~\"$service\"} |~ \"(?i)(error|exception|traceback)\" [1m])) by (compose_service)",
+          "legendFormat": "{{ compose_service }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "bars", "fillOpacity": 50 },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Logs",
+      "type": "logs",
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 12 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "{compose_service=~\"$service\"} |~ \"$search\"",
+          "maxLines": 500
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/monitoring/grafana/dashboards/http-metrics.json
+++ b/monitoring/grafana/dashboards/http-metrics.json
@@ -1,0 +1,126 @@
+{
+  "uid": "http-metrics",
+  "title": "HTTP Metrics",
+  "tags": ["prometheus", "http"],
+  "timezone": "browser",
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "" },
+        "query": "label_values(http_requests_total, job)",
+        "refresh": 2,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=~\"$service\"}[1m])) by (job)",
+          "legendFormat": "{{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=~\"$service\", status_code=~\"5..\"}[1m])) by (job)",
+          "legendFormat": "{{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Request Duration (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=~\"$service\"}[1m])) by (le, job))",
+          "legendFormat": "p50 {{ job }}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=~\"$service\"}[1m])) by (le, job))",
+          "legendFormat": "p95 {{ job }}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=~\"$service\"}[1m])) by (le, job))",
+          "legendFormat": "p99 {{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 5 }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Requests by Status Code",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=~\"$service\"}[1m])) by (status_code)",
+          "legendFormat": "{{ status_code }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "bars", "fillOpacity": 50, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Top Endpoints by Request Count",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "topk(10, sum(increase(http_requests_total{job=~\"$service\"}[5m])) by (method, path))",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true } } }
+      ]
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -14,6 +14,10 @@ upstream grafana {
     server grafana:3000;
 }
 
+upstream prometheus {
+    server prometheus:9090;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -51,6 +55,18 @@ server {
 
     location /api/v1/health {
         proxy_pass http://orders_api;
+    }
+
+    # Prometheus (read-only: GET requests only)
+    location /prometheus/ {
+        limit_except GET {
+            deny all;
+        }
+        proxy_pass http://prometheus/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Grafana (reverse-proxied under /grafana/)

--- a/notifications/src/main.py
+++ b/notifications/src/main.py
@@ -5,9 +5,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
 from prometheus_client import make_asgi_app
-from shared.http_metrics import PrometheusMiddleware
+from shared.http_metrics import GZipMiddleware, PrometheusMiddleware
 
 from src.lifespan import startup, teardown
 from src.routes import router

--- a/orders/src/main.py
+++ b/orders/src/main.py
@@ -3,9 +3,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
 from prometheus_client import make_asgi_app
-from shared.http_metrics import PrometheusMiddleware
+from shared.http_metrics import GZipMiddleware, PrometheusMiddleware
 
 from src.lifespan import startup, teardown
 from src.routes import router

--- a/shared/src/shared/http_metrics.py
+++ b/shared/src/shared/http_metrics.py
@@ -2,6 +2,7 @@ import time
 from collections.abc import MutableMapping
 from typing import Any
 
+from fastapi.middleware.gzip import GZipMiddleware as _GZipMiddleware
 from prometheus_client import Counter, Histogram
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -45,3 +46,17 @@ class PrometheusMiddleware:
             duration = time.perf_counter() - start
             HTTP_REQUESTS_TOTAL.labels(method, path, str(status_code)).inc()
             HTTP_REQUEST_DURATION.labels(method, path).observe(duration)
+
+
+class GZipMiddleware:
+    """GZipMiddleware that skips /metrics to avoid breaking Prometheus scraping."""
+
+    def __init__(self, app: ASGIApp, **kwargs: Any) -> None:
+        self._gzip = _GZipMiddleware(app, **kwargs)
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope.get("path", "").startswith("/metrics"):
+            await self._app(scope, receive, send)
+        else:
+            await self._gzip(scope, receive, send)


### PR DESCRIPTION
## Summary
- Proxy Prometheus through nginx at `/prometheus/` with GET-only restriction (demo users can query but not modify)
- Remove direct port 9090 exposure from docker-compose
- Add custom `GZipMiddleware` wrapper that skips `/metrics` path to fix Prometheus scraping
- Provision two Grafana dashboards (read-only, non-deletable):
  - **HTTP Metrics**: request rate, error rate, latency percentiles (p50/p95/p99), status codes, top endpoints
  - **Application Logs**: log volume by service, error count, live Loki log stream
- Dashboards accessible without login (anonymous Viewer role)
- Update DevTools page with direct dashboard links and read-only badges
- Update README with dashboard URLs

## Test plan
- [ ] `docker compose up` and verify `/prometheus/` loads via nginx
- [ ] Verify POST/DELETE to `/prometheus/` returns 403
- [ ] Verify Grafana dashboards appear at `/grafana/d/http-metrics` and `/grafana/d/application-logs`
- [ ] Verify anonymous access works (no login required to view dashboards)
- [ ] Verify `/metrics` endpoints return uncompressed text (Prometheus scraping works)