### PR TITLE
fix: Loki permission denied crash

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -249,7 +249,7 @@ services:
       - "3100:3100"
     volumes:
       - ./monitoring/loki-config.yml:/etc/loki/local-config.yaml:ro
-      - loki_data:/loki/data
+      - loki_data:/loki
     command: -config.file=/etc/loki/local-config.yaml
     networks:
       - backend_net


### PR DESCRIPTION
## Summary
- Mount Loki volume at `/loki` instead of `/loki/data` so the non-root Loki user (uid 10001) can create subdirectories (`compactor`, `tsdb-shipper-cache`, `chunks`)

## Test plan
- [ ] `docker compose down -v && docker compose up loki` — starts without permission errors
- [ ] `curl http://localhost:3100/ready` returns 200