### PR TITLE
OP012: Provision Grafana dashboards in Helm + Loki datasource

### DIFF
--- a/charts/orders-project/Chart.lock
+++ b/charts/orders-project/Chart.lock
@@ -23,5 +23,14 @@ dependencies:
 - name: notifications
   repository: file://charts/notifications
   version: 0.1.0
-digest: sha256:cbd908b21e9b06f772b6056ebe28b31c296d77684dcf5b84a18504d6023006d1
-generated: "2025-04-21T18:01:33.096097+02:00"
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 69.8.2
+- name: loki
+  repository: https://grafana.github.io/helm-charts
+  version: 6.28.0
+- name: promtail
+  repository: https://grafana.github.io/helm-charts
+  version: 6.16.6
+digest: sha256:4fe1636795f5f08ed9cc02b88b5b434c170422397ebe3ef11177ae781919b982
+generated: "2026-03-16T21:34:59.42489+01:00"

--- a/charts/orders-project/dashboards/application-logs.json
+++ b/charts/orders-project/dashboards/application-logs.json
@@ -1,0 +1,92 @@
+{
+  "uid": "application-logs",
+  "title": "Application Logs",
+  "tags": ["loki", "logs"],
+  "timezone": "browser",
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "" },
+        "query": "label_values(compose_service)",
+        "refresh": 2,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "search",
+        "type": "textbox",
+        "current": { "text": "", "value": "" },
+        "label": "Search"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log Volume",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({compose_service=~\"$service\"} |~ \"$search\" [1m])) by (compose_service)",
+          "legendFormat": "{{ compose_service }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "bars", "fillOpacity": 50, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Logs",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 6 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({compose_service=~\"$service\"} |~ \"(?i)(error|exception|traceback)\" [1m])) by (compose_service)",
+          "legendFormat": "{{ compose_service }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "bars", "fillOpacity": 50 },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Logs",
+      "type": "logs",
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 12 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "{compose_service=~\"$service\"} |~ \"$search\"",
+          "maxLines": 500
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/charts/orders-project/dashboards/event-pipeline.json
+++ b/charts/orders-project/dashboards/event-pipeline.json
@@ -1,0 +1,187 @@
+{
+  "uid": "event-pipeline",
+  "title": "Event Pipeline",
+  "tags": ["prometheus", "streams", "pipeline"],
+  "timezone": "browser",
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "stream",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "" },
+        "query": "label_values(stream_messages_processed_total, stream)",
+        "refresh": 2,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "group",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "" },
+        "query": "label_values(stream_messages_processed_total, group)",
+        "refresh": 2,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Message Throughput (msg/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(stream_messages_processed_total{stream=~\"$stream\", group=~\"$group\"}[1m])) by (stream)",
+          "legendFormat": "{{ stream }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": { "drawStyle": "line", "fillOpacity": 15 }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate by Stream",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(stream_messages_processed_total{stream=~\"$stream\", group=~\"$group\", status=\"error\"}[1m])) by (stream, group)",
+          "legendFormat": "{{ stream }} / {{ group }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Processing Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(stream_message_duration_seconds_bucket{stream=~\"$stream\", group=~\"$group\"}[1m])) by (le, stream))",
+          "legendFormat": "p50 {{ stream }}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(stream_message_duration_seconds_bucket{stream=~\"$stream\", group=~\"$group\"}[1m])) by (le, stream))",
+          "legendFormat": "p95 {{ stream }}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(stream_message_duration_seconds_bucket{stream=~\"$stream\", group=~\"$group\"}[1m])) by (le, stream))",
+          "legendFormat": "p99 {{ stream }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 5 }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Dead-Letter Queue Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(stream_dlq_messages_total{stream=~\"$stream\", group=~\"$group\"}[1m])) by (stream, group)",
+          "legendFormat": "{{ stream }} / {{ group }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "color": { "mode": "fixed", "fixedColor": "orange" }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Success Rate",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(stream_messages_processed_total{stream=~\"$stream\", group=~\"$group\", status=\"success\"}) / sum(stream_messages_processed_total{stream=~\"$stream\", group=~\"$group\"}) * 100"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "red" },
+              { "value": 90, "color": "yellow" },
+              { "value": 99, "color": "green" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Total DLQ Messages",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(stream_dlq_messages_total{stream=~\"$stream\", group=~\"$group\"})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "green" },
+              { "value": 1, "color": "orange" },
+              { "value": 10, "color": "red" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Messages by Consumer Group",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(stream_messages_processed_total{stream=~\"$stream\", group=~\"$group\"}[1m])) by (group)",
+          "legendFormat": "{{ group }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": { "drawStyle": "bars", "fillOpacity": 50, "stacking": { "mode": "normal" } }
+        }
+      }
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/charts/orders-project/dashboards/http-metrics.json
+++ b/charts/orders-project/dashboards/http-metrics.json
@@ -1,0 +1,126 @@
+{
+  "uid": "http-metrics",
+  "title": "HTTP Metrics",
+  "tags": ["prometheus", "http"],
+  "timezone": "browser",
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "" },
+        "query": "label_values(http_requests_total, job)",
+        "refresh": 2,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=~\"$service\"}[1m])) by (job)",
+          "legendFormat": "{{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=~\"$service\", status_code=~\"5..\"}[1m])) by (job)",
+          "legendFormat": "{{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Request Duration (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=~\"$service\"}[1m])) by (le, job))",
+          "legendFormat": "p50 {{ job }}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=~\"$service\"}[1m])) by (le, job))",
+          "legendFormat": "p95 {{ job }}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=~\"$service\"}[1m])) by (le, job))",
+          "legendFormat": "p99 {{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 5 }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Requests by Status Code",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=~\"$service\"}[1m])) by (status_code)",
+          "legendFormat": "{{ status_code }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "bars", "fillOpacity": 50, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Top Endpoints by Request Count",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "" },
+      "targets": [
+        {
+          "expr": "topk(10, sum(increase(http_requests_total{job=~\"$service\"}[5m])) by (method, path))",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true } } }
+      ]
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/charts/orders-project/templates/grafana-dashboards.yaml
+++ b/charts/orders-project/templates/grafana-dashboards.yaml
@@ -1,0 +1,19 @@
+{{- $kps := index .Values "kube-prometheus-stack" }}
+{{- if $kps.enabled }}
+{{- range $name := list "http-metrics" "application-logs" "event-pipeline" }}
+{{- $json := $.Files.Get (printf "dashboards/%s.json" $name) }}
+{{- if $json }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-{{ $name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    grafana_dashboard: "1"
+data:
+  {{ $name }}.json: |-
+{{ $json | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/orders-project/templates/ingress.yaml
+++ b/charts/orders-project/templates/ingress.yaml
@@ -40,6 +40,14 @@ spec:
                 port:
                   number: 8002
 
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: orders-project-kube-prometh-grafana
+                port:
+                  number: 80
+
           - path: /
             pathType: Prefix
             backend:

--- a/charts/orders-project/values.yaml
+++ b/charts/orders-project/values.yaml
@@ -38,6 +38,16 @@ kube-prometheus-stack:
   enabled: true
   grafana:
     adminPassword: admin
+    grafana.ini:
+      server:
+        root_url: "%(protocol)s://%(domain)s/grafana/"
+        serve_from_sub_path: true
+    additionalDataSources:
+      - name: Loki
+        type: loki
+        url: http://loki:3100
+        access: proxy
+        isDefault: false
   prometheus:
     prometheusSpec:
       serviceMonitorSelectorNilUsesHelmValues: false
@@ -46,12 +56,28 @@ loki:
   enabled: true
   deploymentMode: SingleBinary
   loki:
+    auth_enabled: false
     commonConfig:
       replication_factor: 1
     storage:
       type: filesystem
+    schemaConfig:
+      configs:
+        - from: "2024-01-01"
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
   singleBinary:
     replicas: 1
+  read:
+    replicas: 0
+  write:
+    replicas: 0
+  backend:
+    replicas: 0
 
 promtail:
   enabled: true


### PR DESCRIPTION
## Summary
- Provision 3 Grafana dashboards (HTTP Metrics, Application Logs, Event Pipeline) via ConfigMap sidecar auto-discovery
- Add Loki as Grafana datasource so log dashboards work in Kubernetes
- Add `/grafana` ingress route with subpath serving
- Fix Loki Helm values: add required `schemaConfig`, disable SimpleScalable replicas for SingleBinary mode

## Test plan
- [ ] `helm template` renders 3 `grafana-dashboard-*` ConfigMaps with `grafana_dashboard: "1"` label
- [ ] `helm upgrade --install` deploys successfully
- [ ] Grafana accessible at `http://orders.localhost/grafana/`
- [ ] All 3 custom dashboards visible in Grafana
- [ ] Loki datasource configured and working