### PR TITLE
fix: Loki dashboard parse error + retention limits

### DIFF
--- a/charts/orders-project/dashboards/application-logs.json
+++ b/charts/orders-project/dashboards/application-logs.json
@@ -14,6 +14,7 @@
         "query": "label_values(compose_service)",
         "refresh": 2,
         "includeAll": true,
+        "allValue": ".+",
         "current": { "text": "All", "value": "$__all" }
       },
       {

--- a/charts/orders-project/values.yaml
+++ b/charts/orders-project/values.yaml
@@ -42,6 +42,9 @@ kube-prometheus-stack:
       server:
         root_url: "%(protocol)s://%(domain)s/grafana/"
         serve_from_sub_path: true
+      auth.anonymous:
+        enabled: true
+        org_role: Viewer
     additionalDataSources:
       - name: Loki
         type: loki
@@ -51,6 +54,8 @@ kube-prometheus-stack:
   prometheus:
     prometheusSpec:
       serviceMonitorSelectorNilUsesHelmValues: false
+      retention: 3d
+      retentionSize: 256MB
 
 loki:
   enabled: true
@@ -59,6 +64,10 @@ loki:
     auth_enabled: false
     commonConfig:
       replication_factor: 1
+    limits_config:
+      retention_period: 72h
+      ingestion_rate_mb: 4
+      ingestion_burst_size_mb: 8
     storage:
       type: filesystem
     schemaConfig:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -233,6 +233,8 @@ services:
       - "--storage.tsdb.path=/prometheus"
       - "--web.external-url=http://localhost/prometheus/"
       - "--web.route-prefix=/"
+      - "--storage.tsdb.retention.time=3d"
+      - "--storage.tsdb.retention.size=256MB"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus

--- a/monitoring/grafana/dashboards/application-logs.json
+++ b/monitoring/grafana/dashboards/application-logs.json
@@ -14,6 +14,7 @@
         "query": "label_values(compose_service)",
         "refresh": 2,
         "includeAll": true,
+        "allValue": ".+",
         "current": { "text": "All", "value": "$__all" }
       },
       {

--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -21,6 +21,16 @@ schema_config:
         prefix: index_
         period: 24h
 
+limits_config:
+  retention_period: 72h
+  ingestion_rate_mb: 4
+  ingestion_burst_size_mb: 8
+
+compactor:
+  working_directory: /loki/data/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
 storage_config:
   filesystem:
     directory: /loki/chunks


### PR DESCRIPTION
## Summary
- Fix Application Logs dashboard Loki query: use `allValue: ".+"` instead of default `.*` which Loki rejects as empty-compatible
- Add data retention to prevent unbounded storage growth:
  - **Loki**: 72h retention, 4MB/s ingestion rate limit
  - **Prometheus**: 3d time retention + 256MB size cap (both docker-compose and Helm)
- Add anonymous Viewer access to Grafana in Helm values

## Test plan
- [ ] Application Logs dashboard loads without parse errors when "All" services selected
- [ ] `docker compose up` — Loki starts with retention enabled
- [ ] Prometheus `--storage.tsdb.retention.*` flags visible in `/prometheus/flags`