### PR TITLE
fix: filter promtail to application containers only

### DIFF
--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -19,3 +19,7 @@ scrape_configs:
         target_label: "logstream"
       - source_labels: ["__meta_docker_container_log_path"]
         target_label: "__path__"
+      # Only collect logs from application containers
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "(order-service|delivery-service|notifications-service|order-simulator|nginx-proxy|frontend)"
+        action: keep


### PR DESCRIPTION
## Summary
- Add `keep` relabel rule to promtail so it only collects logs from application containers (order-service, delivery-service, notifications-service, order-simulator, nginx-proxy, frontend)
- Drops noisy logs from mongo, redis, loki, grafana, prometheus, promtail

## Test plan
- [ ] Restart promtail → only 6 targets discovered
- [ ] Application Logs dashboard shows only backend service logs
- [ ] No mongo/redis/loki noise in log stream