### PR TITLE
fix: promtail container name regex leading slash

### DIFF
--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -21,5 +21,5 @@ scrape_configs:
         target_label: "__path__"
       # Only collect logs from application containers
       - source_labels: ["__meta_docker_container_name"]
-        regex: "(order-service|delivery-service|notifications-service|order-simulator|nginx-proxy|frontend)"
+        regex: "/?(order-service|delivery-service|notifications-service|order-simulator|nginx-proxy|frontend)"
         action: keep


### PR DESCRIPTION
## Summary
- Docker's `__meta_docker_container_name` includes a leading `/` (e.g. `/order-service`)
- The `keep` regex didn't account for this, so no containers matched and all logs were dropped
- Added `/?` prefix to regex

## Test plan
- [ ] Restart promtail → logs appear in Application Logs dashboard