### PR TITLE
Add Sphinx documentation site with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,39 @@
+name: docs
+
+on:
+  push:
+    branches: [master]
+    paths: [docs/**]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - run: pip install -r docs/requirements.txt
+
+      - run: sphinx-build docs docs/_build/html
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 shared/build/
 shared/src/*.egg-info/
+
+docs/_build/

--- a/README.md
+++ b/README.md
@@ -1,114 +1,14 @@
-# 🧙🏻‍♂️ Orders Project – Microservices Architecture
+# Orders Project
 
-> A complete microservices-based architecture built with FastAPI + MongoDB + Redis, supporting Kubernetes and Docker Compose environments. The project includes a simulated order lifecycle and event-stream communication between services. 
-> 
-> Deployed on my **self-hosted** Kubernetes cluster running on a **Raspberry Pi**, using Ingress NGINX and a Cloudflared tunnel for secure public access at [orders.karolmarszalek.me](https://orders.karolmarszalek.me/).
----
+A microservices-based food delivery system built with **FastAPI + MongoDB + Redis**, supporting **Kubernetes** and **Docker Compose** environments. Features event-driven communication via Redis Streams (SAGA pattern), a full observability stack, and a React frontend.
 
-## 👽 System Architecture Overview
+Deployed on a self-hosted Kubernetes cluster (Raspberry Pi) at [orders.karolmarszalek.me](https://orders.karolmarszalek.me/).
 
-### 🦕 Service Communication & Stream Architecture
+## Architecture
 
 ![Architecture Diagram](assets/arch-diagram.svg)
 
-This system follows a SAGA Pattern for managing distributed transactions across microservices. Services communicate primarily over REST, Web Sockets, and Redis Streams to track and coordinate the order lifecycle. Redis acts as an event bus for both real-time messaging and data decoupling.
-
-The design allows extensibility (e.g., adding new consumers or data pipelines) and cleanly separates responsibilities into domain-driven services. Each service loads its configuration from environment files and connects to MongoDB and Redis.
-
-
-### ☸️ Kubernetes Deployment Architecture
-
-![Kubernetes Diagram](assets/orders-project-v2.svg)
-
-The Kubernetes setup includes Deployments, StatefulSets (Mongo & Redis), ConfigMaps, Secrets, Ingress NGINX with the Cloudflared tunnel, and a CronJob for stock refilling. Each microservice is deployed as a dedicated Kubernetes deployment with a corresponding ClusterIP service.
-
-Three Helm-based init jobs run automatically upon the first deployment:
-
-- **`init-rs-job.yaml`**: Initializes MongoDB replica set (`rs0`) – extendable, depends on your resources and needs.
-     
-- **`init-user-job.yaml`**: Creates the initial MongoDB admin user.
-    
-- **`init-dummy-db-job.yaml`**: Loads demo data into Mongo.
-    
-
-All configurable values (envs, secrets, image tags) can be set in the Helm `values.yaml` in the main chart and its subcharts.
-
-A scheduled **CronJob** runs every 2 hours to simulate stock refill.
-
----
-
-## ⚙️ Tech Stack
-
-### Backend (Python)
-
-- **FastAPI** – for building async REST APIs
-    
-- **Pydantic / pydantic-settings** – for schema validation & env config
-    
-- **Motor** – async MongoDB client
-    
-- **Redis** – pub/sub messaging system
-    
-
-**Dev tooling:**
-
-- `mypy`, `ruff`
-    
-
-### Frontend (React)
-
-- **React 19** + **TypeScript**
-    
-- **Vite** for lightning-fast build & dev
-    
-- **Tailwind CSS** + `shadcn/ui` components
-    
-- **TanStack Query & Router**
-    
-- **Framer Motion** – for animations
-    
-- **Zod** – schema validation
-    
-- **ESLint + Prettier** – code quality
-    
-
----
-
-## 🐍 One UV Environment (Whole Project)
-
-If you want one Python interpreter and one `.venv` for all Python services, run from repo root:
-
-```bash
-uv lock
-uv sync --dev
-```
-
-This creates a shared environment at:
-
-```bash
-.venv/
-```
-
-Check the interpreter path:
-
-```bash
-uv run python -c "import sys; print(sys.executable)"
-```
-
----
-
-## 🐳 Docker Compose (local dev setup)
-
-Requirements:
-
-- Docker + Docker Compose installed
-    
-- Environment files copied into `envs/` (remove `default.` prefix):
-    
-    - `mongo_db.env`, `redis.env`, `simulator.env`, `mongo-keyfile`
-        
-
-### ✅ Startup command:
+## Quick Start
 
 ```bash
 cp envs/default.mongo_db.env envs/mongo_db.env
@@ -119,122 +19,19 @@ cp envs/default.mongo-keyfile envs/mongo-keyfile
 docker compose up --build
 ```
 
-> Frontend available at: [http://localhost:3000](http://localhost:3000/)
+Open [http://localhost](http://localhost) for the frontend, [http://localhost/dev](http://localhost/dev) for dev tools (Grafana, Prometheus, API docs).
 
----
+## Documentation
 
-## ☸️ Kubernetes (Helm deployment)
+Full documentation is available at the [docs site](https://kkaarroollm.github.io/orders-project/).
 
-### 📦 Install using Helm:
+- [Getting Started](https://kkaarroollm.github.io/orders-project/getting-started.html)
+- [Architecture](https://kkaarroollm.github.io/orders-project/architecture.html)
+- [Services](https://kkaarroollm.github.io/orders-project/services.html)
+- [Monitoring](https://kkaarroollm.github.io/orders-project/monitoring.html)
+- [Deployment](https://kkaarroollm.github.io/orders-project/deployment.html)
+- [Development](https://kkaarroollm.github.io/orders-project/development.html)
 
-```bash
-helm install orders ./charts/orders-project
-```
+## Author
 
-Make sure to configure your own secrets, user credentials, and connection strings in the `values.yaml` files across the main chart and subcharts.
-
-On first installation, three `Job` resources are triggered:
-
-- Initializes Mongo replica set (1-node by default)
-    
-- Creates initial database user
-    
-- Loads test data into the database
-    
-
-Includes:
-
-- Ingress (NGINX + Cloudflared Tunnel)
-    
-- StatefulSets for MongoDB and Redis
-    
-- CronJob `stock-refill` that periodically replenishes item stock
-    
-
----
-
-## 🧩 Microservices Overview
-
-| Name                     | Port  | Description                                         |
-|--------------------------|-------|-----------------------------------------------------|
-| `order-service`          | 8003  | Processes customer orders                           |
-| `delivery-service`       | 8001  | Handles shipment and delivery status                |
-| `notifications-service`  | 8002  | Sends updates via Redis Streams                     |
-| `order-simulator`        | -     | Simulates order lifecycle from creation to delivery |
-| `frontend`               | 3000  | React UI built with modern tooling                  |
-| `mongo`                  | 27017 | MongoDB replica (1-node)                            |
-| `redis`                  | 6379  | Redis for pub/sub & messaging                       |
-| `stock-refill` (CronJob) | -     | Periodically refills inventory stock                |
-| `prometheus`             | 9090  | Metrics collection & PromQL queries                 |
-| `grafana`                | 3001  | Dashboards & visualization (proxied at `/grafana/`)  |
-| `loki`                   | 3100  | Log aggregation backend                              |
-| `promtail`               | -     | Collects container logs and ships to Loki            |
-| `nginx`                  | 80    | Reverse proxy for frontend, APIs & Grafana           |
-
----
-
-## 📊 Monitoring & Observability
-
-The project includes a full observability stack:
-
-- **Prometheus** — scrapes `/metrics` from all FastAPI services every 15s
-- **Grafana** — dashboards and log exploration (Loki datasource pre-provisioned)
-- **Loki + Promtail** — aggregates container logs from Docker
-
-### Quick Links (Docker Compose)
-
-| Tool                        | URL                                          | Credentials     |
-|-----------------------------|----------------------------------------------|-----------------|
-| Frontend                    | http://localhost                               | —               |
-| Dev Tools page              | http://localhost/dev                           | —               |
-| Grafana (admin)             | http://localhost/grafana/                      | admin / admin   |
-| HTTP Metrics dashboard      | http://localhost/grafana/d/http-metrics        | — (read-only)   |
-| Application Logs dashboard  | http://localhost/grafana/d/application-logs    | — (read-only)   |
-| Event Pipeline dashboard    | http://localhost/grafana/d/event-pipeline       | — (read-only)   |
-| Prometheus (read-only)      | http://localhost/prometheus/                   | —               |
-| Order Service — API Docs    | http://localhost:8003/docs                     | —               |
-| Delivery Service — API Docs | http://localhost:8001/docs                     | —               |
-| Notifications — API Docs    | http://localhost:8002/docs                     | —               |
-
-Grafana dashboards are accessible without login (anonymous viewer role). Admin access requires credentials above.
-
-All service OpenAPI docs are available only in `DEVELOPMENT` environment.
-
----
-
-## 📁 Project Structure
-
-```plaintext
-.
-├── frontend/               # React + TS + Tailwind UI
-├── orders/                 # FastAPI – orders service
-├── delivery/               # FastAPI – delivery logic
-├── notifications/          # FastAPI – notifications + Redis
-├── shared/                 # Shared Python library (Redis, metrics, settings)
-├── simulator/              # Just Python and streams – generates synthetic events
-├── monitoring/             # Prometheus, Grafana, Loki & Promtail configs
-├── nginx/                  # Nginx reverse proxy configs (dev & prod)
-├── charts/                 # Helm chart & init jobs
-├── envs/                   # All .env files required
-├── scripts/                # Init scripts (replica, seed data)
-├── assets/                 # Architecture diagrams
-└── docker-compose.yaml     # Dev-only deployment stack
-```
-
----
-
-## ✅ TODO
-
-- [ ] Implement CQRS and Event Sourcing
-- [x] Logging & monitoring (Prometheus, Grafana, Loki)
-- [ ] Set up cache invalidation via CronJob
-- [x] Enhance Redis Stream consumers with XPENDING + XCLAIM logic
-- [ ] Unit tests for all services (orders covered, delivery & notifications pending)
-
-
-## 🍺 Author
-
-Made with **beer** by: **kkaarroollm** → [website](https://karolmarszalek.me/)  
-
-Built with: FastAPI, Redis, MongoDB, React, Helm, Docker Compose
-
+Made with **beer** by **kkaarroollm** -- [website](https://karolmarszalek.me/)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,11 @@
+SPHINXBUILD = sphinx-build
+SOURCEDIR   = .
+BUILDDIR    = _build
+
+html:
+	$(SPHINXBUILD) -b html $(SOURCEDIR) $(BUILDDIR)/html
+
+clean:
+	rm -rf $(BUILDDIR)
+
+.PHONY: html clean

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,71 @@
+# Architecture
+
+## Service Communication
+
+![Architecture Diagram](../assets/arch-diagram.svg)
+
+The system follows the **SAGA pattern** for distributed transactions across microservices. Services communicate over:
+
+- **REST APIs** for synchronous requests (order creation, menu queries)
+- **Redis Streams** for asynchronous event-driven messaging (order lifecycle)
+- **WebSockets** for real-time order tracking updates to the frontend
+
+Redis acts as the event bus. Each service publishes domain events and subscribes to relevant streams through consumer groups.
+
+### Stream Flow
+
+```
+Order placed
+  -> orders-stream (order.created)
+     -> delivery-group: creates delivery
+     -> notifications-group: stores status
+
+  -> simulate-order-stream (order.simulate)
+     -> simulator-group: starts lifecycle simulation
+
+Delivery status change
+  -> delivery-status-stream
+     -> delivery-group: updates delivery record
+
+  -> deliveries-stream
+     -> notifications-group: pushes to WebSocket
+
+Order status change
+  -> order-status-stream
+     -> orders-group: updates order record
+```
+
+### Message Envelope
+
+All stream messages are wrapped in a `MessageEnvelope`:
+
+```python
+{
+    "event_type": "order.created",
+    "correlation_id": "uuid",
+    "source": "orders",
+    "timestamp": "2024-01-01T00:00:00Z",
+    "payload": { ... }
+}
+```
+
+The `correlation_id` enables end-to-end tracing across services through Loki logs.
+
+## Kubernetes Deployment
+
+![Kubernetes Diagram](../assets/orders-project-v2.svg)
+
+The Kubernetes setup uses an umbrella Helm chart with:
+
+- **Deployments** for all application services (3 replicas each)
+- **StatefulSets** for MongoDB (replica set) and Redis (persistent)
+- **Ingress NGINX** with Cloudflared tunnel for public access
+- **CronJob** for periodic stock refill
+- **kube-prometheus-stack** for monitoring
+- **Loki + Promtail** for log aggregation
+
+Three init Jobs run on first deployment:
+
+1. **init-rs-job** -- initializes MongoDB replica set
+2. **init-user-job** -- creates MongoDB admin user
+3. **init-dummy-db-job** -- loads demo data

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,12 @@
+project = "Orders Project"
+author = "kkaarroollm"
+copyright = "2024, kkaarroollm"
+
+extensions = ["myst_parser"]
+myst_enable_extensions = ["colon_fence", "deflist"]
+
+html_theme = "furo"
+html_title = "Orders Project"
+html_static_path = []
+
+exclude_patterns = ["_build"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,114 @@
+# Deployment
+
+## Docker Compose
+
+The `docker-compose.yaml` defines the full development stack: application services, databases, monitoring, and reverse proxy.
+
+### Environment Files
+
+Copy the defaults before first run:
+
+```bash
+cp envs/default.mongo_db.env envs/mongo_db.env
+cp envs/default.redis.env envs/redis.env
+cp envs/default.simulator.env envs/simulator.env
+cp envs/default.mongo-keyfile envs/mongo-keyfile
+```
+
+### Commands
+
+```bash
+# Start everything
+docker compose up --build
+
+# Restart after config changes
+docker compose down -v && docker compose up -d
+
+# View logs for a specific service
+docker compose logs -f order-service
+```
+
+### NGINX Proxy Routes
+
+| Path | Backend |
+|------|---------|
+| `/` | Frontend (Vite dev server) |
+| `/api/v1/orders`, `/api/v1/menu` | Order service |
+| `/ws/v1/order-tracking` | Notifications service (WebSocket) |
+| `/grafana/` | Grafana |
+| `/prometheus/` | Prometheus (GET-only) |
+
+## Kubernetes (Helm)
+
+### Chart Structure
+
+```
+charts/orders-project/          # Umbrella chart
+  charts/
+    orders/                     # Order service subchart
+    delivery/                   # Delivery service subchart
+    notifications/              # Notifications service subchart
+    frontend/                   # Frontend subchart
+    simulator/                  # Simulator subchart
+    mongodb/                    # MongoDB StatefulSet
+    redis/                      # Redis StatefulSet
+  dashboards/                   # Grafana dashboard JSONs
+  templates/
+    configs.yaml                # Shared ConfigMaps
+    secrets.yaml                # Shared Secrets
+    ingress.yaml                # Ingress rules
+    grafana-dashboards.yaml     # Dashboard ConfigMaps
+```
+
+External dependencies (from `Chart.yaml`):
+
+- `ingress-nginx` 4.12.1
+- `kube-prometheus-stack` 69.8.2
+- `loki` 6.28.0
+- `promtail` 6.16.6
+
+### Install
+
+```bash
+helm dependency update charts/orders-project
+helm install orders charts/orders-project -n prod --create-namespace
+```
+
+### Configuration
+
+All values are in `charts/orders-project/values.yaml`:
+
+```yaml
+global:
+  mongo:
+    username: root
+    password: <change-me>
+    host: mongo-svc
+    database: food-delivery
+  redis:
+    password: <change-me>
+    host: redis-svc
+```
+
+### Init Jobs
+
+On first install, three Jobs run automatically:
+
+1. **init-rs-job** -- initializes MongoDB replica set (`rs0`)
+2. **init-user-job** -- creates the MongoDB admin user
+3. **init-dummy-db-job** -- loads demo menu data
+
+### Ingress Routes
+
+| Path | Service |
+|------|---------|
+| `/api/v1/orders`, `/api/v1/menu` | orders-svc:8003 |
+| `/ws/v1/order-tracking` | notifications-svc:8002 |
+| `/grafana` | grafana:80 |
+| `/` | frontend-svc:80 |
+
+### Monitoring in Kubernetes
+
+ServiceMonitors are defined for orders, delivery, and notifications services. Grafana dashboards are provisioned via ConfigMaps with the `grafana_dashboard: "1"` label (auto-discovered by the sidecar).
+
+Loki is configured as an additional Grafana datasource in `values.yaml`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,92 @@
+# Development
+
+## Tech Stack
+
+### Backend (Python 3.13+)
+
+- **FastAPI** -- async REST APIs
+- **Pydantic** -- schema validation and settings
+- **Motor** -- async MongoDB client
+- **Redis (async)** -- event bus and pub/sub
+- **prometheus-client** -- metrics exposition
+
+### Frontend
+
+- **React 19** + **TypeScript**
+- **Vite** -- build tool and dev server
+- **Tailwind CSS** + **shadcn/ui** -- styling
+- **TanStack Query & Router** -- data fetching and routing
+- **Zod** -- schema validation
+
+## UV Workspace
+
+The project uses a UV workspace to manage all Python services under a single virtual environment.
+
+```bash
+# Install all dependencies
+uv lock
+uv sync --dev
+
+# Check interpreter
+uv run python -c "import sys; print(sys.executable)"
+```
+
+The root `pyproject.toml` defines workspace members:
+
+```toml
+[tool.uv.workspace]
+members = ["shared", "orders", "delivery", "notifications", "simulator"]
+```
+
+The `shared` package is a workspace dependency used by all services:
+
+```toml
+[project]
+dependencies = ["shared"]
+
+[tool.uv.sources]
+shared = { workspace = true }
+```
+
+## Linting & Type Checking
+
+```bash
+# Ruff linter (all services)
+uv run ruff check .
+
+# Type checker (per service)
+cd orders && uv run ty check
+cd delivery && uv run ty check
+cd notifications && uv run ty check
+```
+
+CI runs both `ruff check` and `ty check` for every service on push/PR.
+
+## Testing
+
+```bash
+# Run tests for a service
+cd orders && uv run pytest
+```
+
+Test dependencies (`pytest`, `pytest-asyncio`) are declared as dev dependencies in each service's `pyproject.toml`.
+
+## Project Structure
+
+```
+.
++-- frontend/               # React + TS + Tailwind UI
++-- orders/                 # FastAPI -- orders service
++-- delivery/               # FastAPI -- delivery logic
++-- notifications/          # FastAPI -- notifications + WebSockets
++-- shared/                 # Shared Python library (Redis, metrics, settings)
++-- simulator/              # Event generator for order lifecycle
++-- monitoring/             # Prometheus, Grafana, Loki & Promtail configs
++-- nginx/                  # Reverse proxy configs (dev & prod)
++-- charts/                 # Helm umbrella chart & subcharts
++-- envs/                   # Environment files
++-- scripts/                # Init scripts (replica set, seed data)
++-- assets/                 # Architecture diagrams
++-- docs/                   # Sphinx documentation (this site)
++-- docker-compose.yaml     # Dev-only deployment stack
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,54 @@
+# Getting Started
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Git
+
+For Kubernetes deployment, you also need:
+- `kubectl` configured for your cluster
+- `helm` v3+
+
+## Docker Compose (Quickstart)
+
+1. Clone and set up environment files:
+
+```bash
+git clone https://github.com/kkaarroollm/orders-project.git
+cd orders-project
+
+cp envs/default.mongo_db.env envs/mongo_db.env
+cp envs/default.redis.env envs/redis.env
+cp envs/default.simulator.env envs/simulator.env
+cp envs/default.mongo-keyfile envs/mongo-keyfile
+```
+
+2. Start everything:
+
+```bash
+docker compose up --build
+```
+
+3. Open the app:
+
+| What | URL |
+|------|-----|
+| Frontend | <http://localhost> |
+| Dev Tools | <http://localhost/dev> |
+| Grafana | <http://localhost/grafana/> |
+| Prometheus | <http://localhost/prometheus/> |
+
+The simulator starts automatically and generates orders.
+
+## Kubernetes (Helm)
+
+```bash
+helm dependency update charts/orders-project
+helm install orders charts/orders-project -n prod --create-namespace
+```
+
+On first install, three Jobs initialize MongoDB (replica set, user, seed data).
+
+Configure credentials and connection strings in `charts/orders-project/values.yaml`.
+
+See {doc}`deployment` for detailed Helm configuration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# Orders Project
+
+A microservices-based food delivery system built with **FastAPI**, **MongoDB**, **Redis**, and **React**. Supports both Docker Compose and Kubernetes (Helm) deployments.
+
+Deployed on a self-hosted Kubernetes cluster (Raspberry Pi) at [orders.karolmarszalek.me](https://orders.karolmarszalek.me/).
+
+## Highlights
+
+- **Event-driven architecture** using Redis Streams with SAGA pattern
+- **Full observability** with Prometheus, Grafana, and Loki
+- **Typed Python** codebase with `ty` type checker and `ruff` linter
+- **UV workspace** for unified dependency management across all services
+- **Helm chart** with monitoring stack (kube-prometheus-stack, Loki, Promtail)
+
+```{toctree}
+:maxdepth: 2
+:caption: Contents
+
+getting-started
+architecture
+services
+monitoring
+deployment
+development
+```

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,79 @@
+# Monitoring & Observability
+
+## Stack
+
+| Tool | Role | Retention |
+|------|------|-----------|
+| Prometheus | Metrics collection (scrapes `/metrics` every 15s) | 3 days / 256 MB |
+| Grafana | Dashboards and log exploration | -- |
+| Loki | Log aggregation backend | 72 hours |
+| Promtail | Collects container logs, ships to Loki | -- |
+
+## Grafana Dashboards
+
+Three pre-provisioned dashboards (read-only, non-deletable):
+
+### HTTP Metrics (`/grafana/d/http-metrics`)
+
+- Request rate per service (req/s)
+- Error rate (5xx) per service
+- Latency percentiles (p50, p95, p99)
+- Requests by status code (stacked bars)
+- Top 10 endpoints by request count
+
+### Application Logs (`/grafana/d/application-logs`)
+
+- Log volume per container (stacked bars)
+- Error log count (error/exception/traceback)
+- Live log stream with full-text search
+- Filterable by container name
+
+### Event Pipeline (`/grafana/d/event-pipeline`)
+
+- Message throughput per stream (msg/s)
+- Error rate by stream and consumer group
+- Processing latency (p50, p95, p99)
+- Dead-letter queue rate and total count
+- Success rate gauge (red/yellow/green)
+- Messages by consumer group (stacked bars)
+
+## Prometheus Metrics
+
+### HTTP Metrics (all services)
+
+Defined in `shared/src/shared/http_metrics.py`:
+
+- `http_requests_total` (Counter) -- labels: `method`, `path`, `status_code`
+- `http_request_duration_seconds` (Histogram) -- labels: `method`, `path`
+
+### Stream Metrics (all consumers)
+
+Defined in `shared/src/shared/redis/metrics.py`:
+
+- `stream_messages_processed_total` (Counter) -- labels: `stream`, `group`, `status`
+- `stream_message_duration_seconds` (Histogram) -- labels: `stream`, `group`
+- `stream_dlq_messages_total` (Counter) -- labels: `stream`, `group`
+
+## Quick Links (Docker Compose)
+
+| Tool | URL | Credentials |
+|------|-----|-------------|
+| Grafana (admin) | <http://localhost/grafana/> | admin / admin |
+| HTTP Metrics | <http://localhost/grafana/d/http-metrics> | -- (anonymous) |
+| Application Logs | <http://localhost/grafana/d/application-logs> | -- (anonymous) |
+| Event Pipeline | <http://localhost/grafana/d/event-pipeline> | -- (anonymous) |
+| Prometheus | <http://localhost/prometheus/> | -- (read-only) |
+
+Grafana dashboards are accessible without login (anonymous viewer role).
+
+## Access Control
+
+- **Prometheus** is proxied through NGINX with GET-only restriction -- demo users can query but cannot modify
+- **Grafana** anonymous users get Viewer role -- can view dashboards but cannot edit or delete
+- Provisioned dashboards are marked `editable: false` and `disableDeletion: true`
+
+## Data Retention
+
+- **Prometheus**: 3-day time retention + 256 MB size cap (whichever triggers first)
+- **Loki**: 72-hour retention with compactor auto-cleanup, 4 MB/s ingestion rate limit
+- **Promtail**: Only collects logs from application containers (order-service, delivery-service, notifications-service, order-simulator, nginx-proxy, frontend)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=7.0
+myst-parser>=3.0
+furo

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,73 @@
+# Services
+
+## Overview
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `order-service` | 8003 | Processes customer orders, manages menu items |
+| `delivery-service` | 8001 | Handles shipment and delivery status tracking |
+| `notifications-service` | 8002 | Real-time updates via WebSockets and Redis Streams |
+| `order-simulator` | -- | Simulates the full order lifecycle (creation to delivery) |
+| `frontend` | 3000 | React UI with menu browsing, cart, ordering, and live tracking |
+
+## Order Service
+
+**Port:** 8003 | **API Docs:** `/docs` (dev only)
+
+Manages orders and menu items. Publishes `order.created` events to Redis Streams.
+
+Endpoints
+: - `GET /api/v1/menu` -- list menu items
+: - `POST /api/v1/orders` -- create an order
+: - `GET /api/v1/orders/{id}` -- get order details
+: - `GET /api/v1/health` -- readiness check
+: - `GET /metrics` -- Prometheus metrics
+
+Dependencies
+: MongoDB, Redis, shared library
+
+## Delivery Service
+
+**Port:** 8001 | **API Docs:** `/docs` (dev only)
+
+Listens for new orders on `orders-stream`, creates delivery records, and tracks status changes.
+
+Endpoints
+: - `GET /api/v1/health` -- readiness check
+: - `GET /metrics` -- Prometheus metrics
+
+Dependencies
+: MongoDB, Redis, shared library
+
+## Notifications Service
+
+**Port:** 8002 | **API Docs:** `/docs` (dev only)
+
+Consumes events from `orders-stream` and `deliveries-stream`. Pushes real-time status updates to connected frontends over WebSockets.
+
+Endpoints
+: - `WS /ws/v1/order-tracking/{order_id}` -- WebSocket for live order status
+: - `GET /api/v1/health` -- readiness check
+: - `GET /metrics` -- Prometheus metrics
+
+Dependencies
+: Redis, shared library
+
+## Order Simulator
+
+Generates synthetic order events to exercise the full pipeline. Simulates order creation, status changes, and delivery completion with configurable delays.
+
+Dependencies
+: Redis, shared library
+
+## Supporting Services
+
+| Service | Purpose |
+|---------|---------|
+| MongoDB | Document store (replica set) |
+| Redis | Event bus (Streams), pub/sub messaging |
+| NGINX | Reverse proxy for frontend, APIs, Grafana, Prometheus |
+| Prometheus | Scrapes `/metrics` from all services every 15s |
+| Grafana | Dashboards and log exploration |
+| Loki | Log aggregation backend |
+| Promtail | Collects container logs, ships to Loki |


### PR DESCRIPTION
## Summary
- Set up Sphinx documentation site with MyST Parser (Markdown) and Furo theme
- Created 7 documentation pages: architecture, services, monitoring, deployment, development, getting started, and index
- Added GitHub Actions workflow to auto-build and deploy docs to GitHub Pages on push to `master`
- Slimmed down README to essentials with link to full docs site
- Added `docs/_build/` to `.gitignore`

## Note
After merging, enable GitHub Pages in repo settings → Pages → Source: **GitHub Actions**.

## Test plan
- [x] `sphinx-build docs docs/_build/html` builds with no warnings
- [ ] After merge, verify GitHub Actions workflow runs successfully
- [ ] Verify docs site at https://kkaarroollm.github.io/orders-project/