### PR TITLE
Add custom domain for docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Open [http://localhost](http://localhost) for the frontend, [http://localhost/de
 
 ## Documentation
 
-Full documentation is available at the [docs site](https://kkaarroollm.github.io/orders-project/).
+Full documentation is available at the [docs site](https://docs.orders.karolmarszalek.me/).
 
-- [Getting Started](https://kkaarroollm.github.io/orders-project/getting-started.html)
-- [Architecture](https://kkaarroollm.github.io/orders-project/architecture.html)
-- [Services](https://kkaarroollm.github.io/orders-project/services.html)
-- [Monitoring](https://kkaarroollm.github.io/orders-project/monitoring.html)
-- [Deployment](https://kkaarroollm.github.io/orders-project/deployment.html)
-- [Development](https://kkaarroollm.github.io/orders-project/development.html)
+- [Getting Started](https://docs.orders.karolmarszalek.me/getting-started.html)
+- [Architecture](https://docs.orders.karolmarszalek.me/architecture.html)
+- [Services](https://docs.orders.karolmarszalek.me/services.html)
+- [Monitoring](https://docs.orders.karolmarszalek.me/monitoring.html)
+- [Deployment](https://docs.orders.karolmarszalek.me/deployment.html)
+- [Development](https://docs.orders.karolmarszalek.me/development.html)
 
 ## Author
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.orders.karolmarszalek.me

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,5 +8,6 @@ myst_enable_extensions = ["colon_fence", "deflist"]
 html_theme = "furo"
 html_title = "Orders Project"
 html_static_path = []
+html_extra_path = ["CNAME"]
 
 exclude_patterns = ["_build"]


### PR DESCRIPTION
## Summary
- Add CNAME file (`docs.orders.karolmarszalek.me`) to Sphinx build output
- Update all documentation links in README to use custom domain

## Prerequisites
- Cloudflare DNS: `CNAME docs.orders → kkaarroollm.github.io` (DNS only, grey cloud)
- GitHub Pages: custom domain set to `docs.orders.karolmarszalek.me`, HTTPS enforced