### PR TITLE
Rewrite docs with accurate architecture patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orders Project
 
-A microservices-based food delivery system built with **FastAPI + MongoDB + Redis**, supporting **Kubernetes** and **Docker Compose** environments. Features event-driven communication via Redis Streams (SAGA pattern), a full observability stack, and a React frontend.
+A microservices-based food delivery system built with **FastAPI + MongoDB + Redis**, supporting **Kubernetes** and **Docker Compose** environments. Features event-driven choreography via Redis Streams, a full observability stack, and a React frontend.
 
 Deployed on a self-hosted Kubernetes cluster (Raspberry Pi) at [orders.karolmarszalek.me](https://orders.karolmarszalek.me/).
 
@@ -23,14 +23,14 @@ Open [http://localhost](http://localhost) for the frontend, [http://localhost/de
 
 ## Documentation
 
-Full documentation is available at the [docs site](https://kkaarroollm.github.io/orders-project/).
+Full documentation is available at the [docs site](https://docs.orders.karolmarszalek.me/).
 
-- [Getting Started](https://kkaarroollm.github.io/orders-project/getting-started.html)
-- [Architecture](https://kkaarroollm.github.io/orders-project/architecture.html)
-- [Services](https://kkaarroollm.github.io/orders-project/services.html)
-- [Monitoring](https://kkaarroollm.github.io/orders-project/monitoring.html)
-- [Deployment](https://kkaarroollm.github.io/orders-project/deployment.html)
-- [Development](https://kkaarroollm.github.io/orders-project/development.html)
+- [Getting Started](https://docs.orders.karolmarszalek.me/getting-started.html)
+- [Architecture](https://docs.orders.karolmarszalek.me/architecture.html)
+- [Services](https://docs.orders.karolmarszalek.me/services.html)
+- [Monitoring](https://docs.orders.karolmarszalek.me/monitoring.html)
+- [Deployment](https://docs.orders.karolmarszalek.me/deployment.html)
+- [Development](https://docs.orders.karolmarszalek.me/development.html)
 
 ## Author
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,71 +1,215 @@
 # Architecture
 
-## Service Communication
+## Design Patterns & Principles
+
+### Event-Driven Choreography
+
+The system uses **choreography** over orchestration -- there is no central coordinator managing workflows. Each service independently reacts to domain events published on Redis Streams and emits its own events in response.
+
+This means:
+
+- **Zero inter-service REST calls.** Services never call each other directly. The only REST endpoints face the client (browser).
+- **Loose coupling.** Adding a new consumer (e.g., an analytics service) requires zero changes to existing services -- just subscribe to the relevant stream.
+- **Independent deployability.** Any service can be restarted or redeployed without breaking the pipeline.
+
+### Why Not SAGA?
+
+A SAGA pattern implies a coordinator (orchestrator) or explicit compensation logic to undo steps on failure. This system doesn't have either -- if an event fails processing, it's retried and eventually moved to a dead-letter queue. The tradeoff: simpler implementation, but no automatic rollback across services.
+
+### Transactional Outbox (Simplified)
+
+The order service uses a **write-then-publish** approach:
+
+1. A MongoDB transaction atomically validates stock and creates the order
+2. Only after the transaction commits, the event is published to Redis Streams
+
+This avoids the dual-write problem where a crash between database write and event publish could leave the system in an inconsistent state. The tradeoff vs. a full outbox pattern: if the process crashes after commit but before publish, the event is lost. For a demo system, this is acceptable.
+
+```python
+# Simplified flow in order_service.py
+async with transaction() as session:
+    await menu_repo.decrement_stock(item_id, quantity, session)
+    order_id = await order_repo.create(order_data, session)
+
+# Published only after successful commit
+await publisher.publish(orders_stream, order_event)
+```
+
+---
+
+## System Overview
 
 ![Architecture Diagram](../assets/arch-diagram.svg)
 
-The system follows the **SAGA pattern** for distributed transactions across microservices. Services communicate over:
+### Communication Protocols
 
-- **REST APIs** for synchronous requests (order creation, menu queries)
-- **Redis Streams** for asynchronous event-driven messaging (order lifecycle)
-- **WebSockets** for real-time order tracking updates to the frontend
+| Layer | Protocol | Purpose |
+|-------|----------|---------|
+| Client ↔ API | **REST** (HTTP/1.1) | Order creation, menu queries |
+| Client ↔ Notifications | **WebSocket** | Real-time order tracking with ping/pong keepalive |
+| Service ↔ Service | **Redis Streams** | Async event-driven messaging with consumer groups |
+| Service ↔ MongoDB | **Wire Protocol** | ACID transactions over replica set |
 
-Redis acts as the event bus. Each service publishes domain events and subscribes to relevant streams through consumer groups.
+No gRPC, no GraphQL, no SSE -- intentionally simple protocol choices.
 
-### Stream Flow
+---
+
+## Redis Streams as an Event Bus
+
+Redis Streams provide a **persistent, ordered, append-only log** with consumer group semantics -- similar in concept to Kafka topics and consumer groups, but embedded in Redis.
+
+### Why Redis Streams Over Alternatives?
+
+| Feature | Redis Streams | Redis Pub/Sub | RabbitMQ | Kafka |
+|---------|:---:|:---:|:---:|:---:|
+| Message persistence | ✅ | ❌ | ✅ | ✅ |
+| Consumer groups | ✅ | ❌ | ✅ | ✅ |
+| Message acknowledgment | ✅ | ❌ | ✅ | ✅ |
+| Replay from offset | ✅ | ❌ | ❌ | ✅ |
+| Already in the stack | ✅ | ✅ | ❌ | ❌ |
+| Operational complexity | Low | Low | Medium | High |
+
+Redis was already needed for caching. Streams add event bus capabilities without introducing another infrastructure component.
+
+### Consumer Group Mechanics
+
+Each service registers a **consumer group** on the streams it cares about:
 
 ```
-Order placed
-  -> orders-stream (order.created)
-     -> delivery-group: creates delivery
-     -> notifications-group: stores status
-
-  -> simulate-order-stream (order.simulate)
-     -> simulator-group: starts lifecycle simulation
-
-Delivery status change
-  -> delivery-status-stream
-     -> delivery-group: updates delivery record
-
-  -> deliveries-stream
-     -> notifications-group: pushes to WebSocket
-
-Order status change
-  -> order-status-stream
-     -> orders-group: updates order record
+XREADGROUP GROUP orders-group consumer-1 COUNT 10 BLOCK 5000 STREAMS orders-stream >
 ```
+
+- `GROUP orders-group` -- the consumer group name (one per service)
+- `consumer-1` -- individual consumer within the group (one per pod/replica)
+- `COUNT 10` -- batch size per read
+- `BLOCK 5000` -- block for 5 seconds if no new messages
+- `>` -- only read new (unacknowledged) messages
+
+After successful processing, the message is acknowledged:
+
+```
+XACK orders-stream orders-group <message-id>
+```
+
+### Retry & Dead-Letter Queue
+
+Unacknowledged messages are automatically reclaimed after a timeout using `XAUTOCLAIM`. A retry counter tracks attempts per message:
+
+```
+Message fails processing
+  → stays in pending entries list (PEL)
+  → XAUTOCLAIM reclaims it after idle timeout
+  → retry counter incremented (stored in Redis key)
+  → if retries > max_retries → XADD to dead-letters stream
+```
+
+The dead-letter stream preserves the original message, stream name, group, and error information for manual inspection.
 
 ### Message Envelope
 
-All stream messages are wrapped in a `MessageEnvelope`:
+Every event is wrapped in a standardized envelope:
 
-```python
+```
 {
-    "event_type": "order.created",
-    "correlation_id": "uuid",
-    "source": "orders",
-    "timestamp": "2024-01-01T00:00:00Z",
-    "payload": { ... }
+  "event_type": "order.created",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440000",
+  "source": "orders-service",
+  "timestamp": "2024-12-01T14:30:00Z",
+  "payload": { "order_id": "...", "items": [...] }
 }
 ```
 
-The `correlation_id` enables end-to-end tracing across services through Loki logs.
+The `correlation_id` follows an event across all services and appears in every log line, enabling end-to-end tracing through Loki without a dedicated tracing system.
+
+---
+
+## Event Flow
+
+### Order Lifecycle
+
+```
+┌─────────┐     POST /orders      ┌────────────────┐
+│ Browser  │ ──────────────────── │ Order Service   │
+└─────────┘                       └───────┬────────┘
+                                          │ order.created
+                                          ▼
+                                  ┌───────────────┐
+                              ┌──│ orders-stream  │──┐
+                              │  └───────────────┘   │
+                              ▼                      ▼
+                    ┌──────────────┐      ┌──────────────────┐
+                    │ Delivery Svc │      │ Notifications Svc│
+                    └──────┬───────┘      └────────┬─────────┘
+                           │                       │
+                           │ delivery.created      │ WebSocket push
+                           ▼                       ▼
+                   ┌─────────────────┐     ┌─────────┐
+                   │deliveries-stream│────▶│ Browser  │
+                   └─────────────────┘     └─────────┘
+```
+
+### Simulation Pipeline
+
+The simulator drives the order through realistic status transitions with configurable delays:
+
+```
+Order:    created → confirmed → preparing → out_for_delivery
+Delivery: waiting → on_the_way → delivered
+```
+
+Each transition publishes a status update event, which the corresponding service picks up and persists.
+
+### Stream Topology
+
+| Stream | Publisher | Consumers |
+|--------|-----------|-----------|
+| `orders-stream` | Order Service | Delivery, Notifications |
+| `deliveries-stream` | Delivery Service | Notifications |
+| `order-status-stream` | Simulator | Order Service |
+| `delivery-status-stream` | Simulator | Delivery Service |
+| `simulate-order-stream` | Order Service | Simulator |
+| `simulate-delivery-stream` | Delivery Service | Simulator |
+| `dead-letters` | Any consumer (on failure) | Manual inspection |
+
+---
+
+## MongoDB & Transactions
+
+MongoDB runs as a **replica set** (`rs0`), which is required for multi-document ACID transactions.
+
+The order creation flow uses transactions to ensure atomicity:
+
+- Stock is decremented and the order is created in a single transaction
+- If stock is insufficient, the entire transaction rolls back
+- The event is published only after a successful commit
+
+```python
+class MongoTransactionManager:
+    async def transaction(self):
+        async with await self.client.start_session() as session:
+            async with session.start_transaction():
+                yield session
+```
+
+This prevents overselling: two concurrent orders for the last item will have one succeed and one roll back.
+
+---
 
 ## Kubernetes Deployment
 
 ![Kubernetes Diagram](../assets/orders-project-v2.svg)
 
-The Kubernetes setup uses an umbrella Helm chart with:
+The production deployment uses an **umbrella Helm chart** with subcharts for each service and external dependencies:
 
-- **Deployments** for all application services (3 replicas each)
-- **StatefulSets** for MongoDB (replica set) and Redis (persistent)
+- **Deployments** for stateless application services
+- **StatefulSets** for MongoDB (replica set) and Redis (persistent storage)
 - **Ingress NGINX** with Cloudflared tunnel for public access
-- **CronJob** for periodic stock refill
-- **kube-prometheus-stack** for monitoring
-- **Loki + Promtail** for log aggregation
+- **CronJob** for periodic stock refill (keeps the demo running)
+- **kube-prometheus-stack** for monitoring (Prometheus + Grafana)
+- **Loki + Promtail** for centralized log aggregation
 
 Three init Jobs run on first deployment:
 
 1. **init-rs-job** -- initializes MongoDB replica set
 2. **init-user-job** -- creates MongoDB admin user
-3. **init-dummy-db-job** -- loads demo data
+3. **init-dummy-db-job** -- loads demo menu data

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,16 +2,16 @@
 
 ## Prerequisites
 
-- Docker and Docker Compose
+- Docker and Docker Compose v2
 - Git
 
-For Kubernetes deployment, you also need:
+For Kubernetes deployment:
 - `kubectl` configured for your cluster
 - `helm` v3+
 
 ## Docker Compose (Quickstart)
 
-1. Clone and set up environment files:
+### 1. Clone and configure
 
 ```bash
 git clone https://github.com/kkaarroollm/orders-project.git
@@ -23,22 +23,31 @@ cp envs/default.simulator.env envs/simulator.env
 cp envs/default.mongo-keyfile envs/mongo-keyfile
 ```
 
-2. Start everything:
+### 2. Start everything
 
 ```bash
 docker compose up --build
 ```
 
-3. Open the app:
+This brings up all application services, MongoDB, Redis, the monitoring stack, and an NGINX reverse proxy. First startup takes a couple of minutes while images build and MongoDB initializes.
+
+### 3. Explore
 
 | What | URL |
 |------|-----|
 | Frontend | <http://localhost> |
 | Dev Tools | <http://localhost/dev> |
-| Grafana | <http://localhost/grafana/> |
-| Prometheus | <http://localhost/prometheus/> |
+| Grafana dashboards | <http://localhost/grafana/> |
+| Prometheus (read-only) | <http://localhost/prometheus/> |
 
-The simulator starts automatically and generates orders.
+The **simulator starts automatically** and generates orders with realistic delays. You'll see orders flowing through the pipeline within seconds.
+
+### 4. Try it yourself
+
+1. Open <http://localhost> and browse the menu
+2. Add items to your cart and place an order
+3. Watch the order status update in real-time on the tracking page
+4. Open the [Event Pipeline dashboard](http://localhost/grafana/d/event-pipeline) to see the messages flowing through Redis Streams
 
 ## Kubernetes (Helm)
 
@@ -47,8 +56,8 @@ helm dependency update charts/orders-project
 helm install orders charts/orders-project -n prod --create-namespace
 ```
 
-On first install, three Jobs initialize MongoDB (replica set, user, seed data).
+On first install, three init Jobs automatically set up MongoDB (replica set, admin user, demo data).
 
 Configure credentials and connection strings in `charts/orders-project/values.yaml`.
 
-See {doc}`deployment` for detailed Helm configuration.
+See {doc}`deployment` for the full Helm configuration reference.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,17 @@
 # Orders Project
 
-A microservices-based food delivery system built with **FastAPI**, **MongoDB**, **Redis**, and **React**. Supports both Docker Compose and Kubernetes (Helm) deployments.
+A microservices-based food delivery system exploring **event-driven architecture**, **distributed systems patterns**, and **container orchestration**. Built with FastAPI, MongoDB, Redis Streams, and React.
 
 Deployed on a self-hosted Kubernetes cluster (Raspberry Pi) at [orders.karolmarszalek.me](https://orders.karolmarszalek.me/).
 
-## Highlights
+## What Makes This Interesting
 
-- **Event-driven architecture** using Redis Streams with SAGA pattern
-- **Full observability** with Prometheus, Grafana, and Loki
-- **Typed Python** codebase with `ty` type checker and `ruff` linter
-- **UV workspace** for unified dependency management across all services
-- **Helm chart** with monitoring stack (kube-prometheus-stack, Loki, Promtail)
+- **Event-driven choreography** -- services communicate exclusively through Redis Streams, with no synchronous inter-service calls
+- **Guaranteed message delivery** -- consumer groups, automatic retries, and a dead-letter queue ensure no event is silently lost
+- **ACID transactions + eventual consistency** -- MongoDB transactions guard local state, while async events propagate changes across services
+- **Real-time push** -- WebSocket connections deliver order status updates to the browser the moment they happen
+- **Full observability** -- Prometheus metrics, Grafana dashboards, and Loki log aggregation with structured correlation IDs
+- **Dual deployment** -- runs identically on Docker Compose (local) and Kubernetes with Helm (production)
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,19 +1,23 @@
 # Monitoring & Observability
 
+The project implements the **three pillars of observability**: metrics (Prometheus), logs (Loki), and real-time dashboards (Grafana). Every service exposes a `/metrics` endpoint, and all container logs are collected automatically.
+
 ## Stack
 
 | Tool | Role | Retention |
 |------|------|-----------|
-| Prometheus | Metrics collection (scrapes `/metrics` every 15s) | 3 days / 256 MB |
-| Grafana | Dashboards and log exploration | -- |
-| Loki | Log aggregation backend | 72 hours |
-| Promtail | Collects container logs, ships to Loki | -- |
+| **Prometheus** | Time-series metrics, scrapes `/metrics` every 15s | 3 days / 256 MB |
+| **Grafana** | Visualization, dashboards, log exploration | -- |
+| **Loki** | Log aggregation (like Prometheus, but for logs) | 72 hours |
+| **Promtail** | Log shipper, Docker service discovery | -- |
 
 ## Grafana Dashboards
 
-Three pre-provisioned dashboards (read-only, non-deletable):
+Three pre-provisioned, read-only dashboards ship with the project. They're automatically loaded on startup (Docker Compose: volume mounts, Kubernetes: ConfigMap sidecar).
 
 ### HTTP Metrics (`/grafana/d/http-metrics`)
+
+Answers: *"Is the API healthy? Where are the bottlenecks?"*
 
 - Request rate per service (req/s)
 - Error rate (5xx) per service
@@ -23,57 +27,82 @@ Three pre-provisioned dashboards (read-only, non-deletable):
 
 ### Application Logs (`/grafana/d/application-logs`)
 
+Answers: *"What happened? What errors are occurring?"*
+
 - Log volume per container (stacked bars)
-- Error log count (error/exception/traceback)
+- Error log count (error/exception/traceback keywords)
 - Live log stream with full-text search
 - Filterable by container name
 
 ### Event Pipeline (`/grafana/d/event-pipeline`)
 
+Answers: *"Is the event bus healthy? Are messages being processed?"*
+
 - Message throughput per stream (msg/s)
-- Error rate by stream and consumer group
+- Processing error rate by stream and consumer group
 - Processing latency (p50, p95, p99)
-- Dead-letter queue rate and total count
-- Success rate gauge (red/yellow/green)
+- Dead-letter queue rate and cumulative count
+- Success rate gauge (green > 99%, yellow > 95%, red below)
 - Messages by consumer group (stacked bars)
 
 ## Prometheus Metrics
 
 ### HTTP Metrics (all services)
 
-Defined in `shared/src/shared/http_metrics.py`:
+Defined in `shared/src/shared/http_metrics.py`. Middleware automatically instruments every request.
 
-- `http_requests_total` (Counter) -- labels: `method`, `path`, `status_code`
-- `http_request_duration_seconds` (Histogram) -- labels: `method`, `path`
+| Metric | Type | Labels |
+|--------|------|--------|
+| `http_requests_total` | Counter | `method`, `path`, `status_code` |
+| `http_request_duration_seconds` | Histogram | `method`, `path` |
+
+:::{note}
+The GZip middleware is configured to skip `/metrics` to prevent Prometheus from receiving compressed responses it can't parse.
+:::
 
 ### Stream Metrics (all consumers)
 
-Defined in `shared/src/shared/redis/metrics.py`:
+Defined in `shared/src/shared/redis/metrics.py`. Consumer group processing is automatically instrumented.
 
-- `stream_messages_processed_total` (Counter) -- labels: `stream`, `group`, `status`
-- `stream_message_duration_seconds` (Histogram) -- labels: `stream`, `group`
-- `stream_dlq_messages_total` (Counter) -- labels: `stream`, `group`
+| Metric | Type | Labels |
+|--------|------|--------|
+| `stream_messages_processed_total` | Counter | `stream`, `group`, `status` |
+| `stream_message_duration_seconds` | Histogram | `stream`, `group` |
+| `stream_dlq_messages_total` | Counter | `stream`, `group` |
+
+The `status` label on `stream_messages_processed_total` distinguishes `success` from `error`, enabling per-stream error rate calculations.
 
 ## Quick Links (Docker Compose)
 
-| Tool | URL | Credentials |
-|------|-----|-------------|
+| Tool | URL | Access |
+|------|-----|--------|
 | Grafana (admin) | <http://localhost/grafana/> | admin / admin |
-| HTTP Metrics | <http://localhost/grafana/d/http-metrics> | -- (anonymous) |
-| Application Logs | <http://localhost/grafana/d/application-logs> | -- (anonymous) |
-| Event Pipeline | <http://localhost/grafana/d/event-pipeline> | -- (anonymous) |
-| Prometheus | <http://localhost/prometheus/> | -- (read-only) |
-
-Grafana dashboards are accessible without login (anonymous viewer role).
+| HTTP Metrics dashboard | <http://localhost/grafana/d/http-metrics> | anonymous viewer |
+| Application Logs dashboard | <http://localhost/grafana/d/application-logs> | anonymous viewer |
+| Event Pipeline dashboard | <http://localhost/grafana/d/event-pipeline> | anonymous viewer |
+| Prometheus | <http://localhost/prometheus/> | read-only (GET only) |
 
 ## Access Control
 
-- **Prometheus** is proxied through NGINX with GET-only restriction -- demo users can query but cannot modify
-- **Grafana** anonymous users get Viewer role -- can view dashboards but cannot edit or delete
+Demo-safe by default:
+
+- **Prometheus** is proxied through NGINX with `limit_except GET { deny all; }` -- users can query metrics but cannot modify configuration or delete data
+- **Grafana** anonymous users get the Viewer role -- dashboards are visible without login, but editing and deletion are blocked
 - Provisioned dashboards are marked `editable: false` and `disableDeletion: true`
 
 ## Data Retention
 
+Lightweight retention policies keep resource usage bounded, which matters on a Raspberry Pi cluster:
+
 - **Prometheus**: 3-day time retention + 256 MB size cap (whichever triggers first)
-- **Loki**: 72-hour retention with compactor auto-cleanup, 4 MB/s ingestion rate limit
-- **Promtail**: Only collects logs from application containers (order-service, delivery-service, notifications-service, order-simulator, nginx-proxy, frontend)
+- **Loki**: 72-hour retention with compactor auto-cleanup, 4 MB/s ingestion rate limit, 8 MB burst
+- **Promtail**: Only collects logs from application containers (order-service, delivery-service, notifications-service, order-simulator, nginx-proxy, frontend) -- monitoring stack logs are excluded to avoid feedback loops
+
+## Correlation & Tracing
+
+Instead of a dedicated tracing system (Jaeger, Zipkin), the project uses `correlation_id` propagation:
+
+1. Order service generates a UUID `correlation_id` when an order is created
+2. The ID is included in every event envelope published to Redis Streams
+3. Every service logs the `correlation_id` with each action
+4. In Loki/Grafana, you can filter by `correlation_id` to see the full lifecycle of an order across all services

--- a/docs/services.md
+++ b/docs/services.md
@@ -2,72 +2,133 @@
 
 ## Overview
 
-| Service | Port | Description |
-|---------|------|-------------|
-| `order-service` | 8003 | Processes customer orders, manages menu items |
-| `delivery-service` | 8001 | Handles shipment and delivery status tracking |
-| `notifications-service` | 8002 | Real-time updates via WebSockets and Redis Streams |
-| `order-simulator` | -- | Simulates the full order lifecycle (creation to delivery) |
-| `frontend` | 3000 | React UI with menu browsing, cart, ordering, and live tracking |
+```
+┌──────────────────────────────────────────────────────────┐
+│                      NGINX Proxy                          │
+│  / → Frontend  │  /api → Orders  │  /ws → Notifications  │
+└──────────────────────────────────────────────────────────┘
+         │                │                    │
+    ┌────▼────┐    ┌──────▼──────┐    ┌───────▼────────┐
+    │Frontend │    │Order Service│    │Notifications   │
+    │ (React) │    │  (FastAPI)  │    │   (FastAPI)    │
+    └─────────┘    └──────┬──────┘    └───────┬────────┘
+                          │                    │
+                   ┌──────▼──────┐    ┌───────▼────────┐
+                   │  Delivery   │    │   Simulator    │
+                   │  (FastAPI)  │    │   (Python)     │
+                   └─────────────┘    └────────────────┘
+```
+
+| Service | Port | Role |
+|---------|------|------|
+| `order-service` | 8003 | Order management, menu, stock control |
+| `delivery-service` | 8001 | Delivery record creation and tracking |
+| `notifications-service` | 8002 | WebSocket gateway for real-time updates |
+| `order-simulator` | -- | Drives order lifecycle transitions |
+| `frontend` | 3000 | React UI for browsing, ordering, tracking |
+
+---
 
 ## Order Service
 
-**Port:** 8003 | **API Docs:** `/docs` (dev only)
-
-Manages orders and menu items. Publishes `order.created` events to Redis Streams.
+**The entry point for all business logic.** Handles order creation with stock validation inside MongoDB transactions, and publishes domain events to Redis Streams.
 
 Endpoints
-: - `GET /api/v1/menu` -- list menu items
-: - `POST /api/v1/orders` -- create an order
-: - `GET /api/v1/orders/{id}` -- get order details
+: - `GET /api/v1/menu` -- list menu items with stock levels
+: - `POST /api/v1/orders` -- create an order (validates stock, decrements atomically)
+: - `GET /api/v1/orders/{id}` -- get order details and current status
 : - `GET /api/v1/health` -- readiness check
 : - `GET /metrics` -- Prometheus metrics
 
-Dependencies
-: MongoDB, Redis, shared library
+Publishes to
+: `orders-stream`, `simulate-order-stream`
+
+Consumes from
+: `order-status-stream` (status updates from simulator)
+
+Key behavior
+: Order creation runs inside a MongoDB transaction. Stock is checked and decremented atomically -- if two users order the last pizza simultaneously, one gets the order and the other gets a 400 error. The event is published only after the transaction commits.
+
+---
 
 ## Delivery Service
 
-**Port:** 8001 | **API Docs:** `/docs` (dev only)
-
-Listens for new orders on `orders-stream`, creates delivery records, and tracks status changes.
+**Reacts to orders reaching "out for delivery" status.** Creates delivery records and tracks the delivery lifecycle.
 
 Endpoints
 : - `GET /api/v1/health` -- readiness check
 : - `GET /metrics` -- Prometheus metrics
 
-Dependencies
-: MongoDB, Redis, shared library
+Publishes to
+: `deliveries-stream`, `simulate-delivery-stream`
+
+Consumes from
+: `orders-stream` (new orders), `delivery-status-stream` (status updates from simulator)
+
+Key behavior
+: Listens to `orders-stream` and only acts when an order reaches `out_for_delivery` status. Creates a delivery record in MongoDB and publishes a `delivery.created` event. Has no REST API for delivery management -- everything is event-driven.
+
+---
 
 ## Notifications Service
 
-**Port:** 8002 | **API Docs:** `/docs` (dev only)
-
-Consumes events from `orders-stream` and `deliveries-stream`. Pushes real-time status updates to connected frontends over WebSockets.
+**The WebSocket gateway.** Bridges the event bus to the browser, pushing real-time status updates to connected clients.
 
 Endpoints
-: - `WS /ws/v1/order-tracking/{order_id}` -- WebSocket for live order status
+: - `WS /ws/v1/order-tracking/{order_id}` -- WebSocket for live order tracking
 : - `GET /api/v1/health` -- readiness check
 : - `GET /metrics` -- Prometheus metrics
 
-Dependencies
-: Redis, shared library
+Consumes from
+: `orders-stream`, `deliveries-stream`
+
+Key behavior
+: When a client connects via WebSocket, the service first checks Redis cache for the latest known status (instant response), then keeps the connection alive and pushes updates as they arrive from the event bus. Uses ping/pong frames with a 60-second timeout for keepalive. No database dependency -- purely stateless, backed by Redis.
+
+---
 
 ## Order Simulator
 
-Generates synthetic order events to exercise the full pipeline. Simulates order creation, status changes, and delivery completion with configurable delays.
+**Drives the demo.** Simulates realistic order lifecycle transitions with configurable delays, making the system useful without manual interaction.
 
-Dependencies
-: Redis, shared library
+Consumes from
+: `simulate-order-stream`, `simulate-delivery-stream`
 
-## Supporting Services
+Publishes to
+: `order-status-stream`, `delivery-status-stream`
 
-| Service | Purpose |
-|---------|---------|
-| MongoDB | Document store (replica set) |
-| Redis | Event bus (Streams), pub/sub messaging |
-| NGINX | Reverse proxy for frontend, APIs, Grafana, Prometheus |
-| Prometheus | Scrapes `/metrics` from all services every 15s |
-| Grafana | Dashboards and log exploration |
-| Loki | Log aggregation backend |
-| Promtail | Collects container logs, ships to Loki |
+Status transitions
+: ```
+  Order:    created → confirmed → preparing → out_for_delivery
+  Delivery: waiting → on_the_way → delivered
+  ```
+
+Each transition has a randomized delay (configurable via environment variables) to simulate real-world processing times.
+
+---
+
+## Frontend
+
+**React 19 + TypeScript** single-page application with:
+
+- Menu browsing with stock indicators
+- Shopping cart with real-time validation
+- Order placement with instant feedback
+- Live order tracking via WebSocket connection
+- Dev tools page with links to Grafana dashboards and API docs
+
+Built with Vite, styled with Tailwind CSS + shadcn/ui, data fetching via TanStack Query, routing via TanStack Router.
+
+---
+
+## Supporting Infrastructure
+
+| Service | Role | Details |
+|---------|------|---------|
+| **MongoDB** | Document store | Replica set (`rs0`) for transaction support, keyfile auth |
+| **Redis** | Event bus + cache | Streams with consumer groups, status caching with 24h TTL |
+| **NGINX** | Reverse proxy | Routes traffic, WebSocket upgrade, Prometheus GET-only restriction |
+| **Prometheus** | Metrics | Scrapes `/metrics` from all services every 15s |
+| **Grafana** | Dashboards | 3 pre-provisioned dashboards, anonymous viewer access |
+| **Loki** | Log aggregation | Receives logs from Promtail, 72h retention |
+| **Promtail** | Log collector | Docker service discovery, filters to app containers only |


### PR DESCRIPTION
## Summary
- Replace SAGA pattern references with **event-driven choreography** (the actual pattern)
- Add detailed sections on Redis Streams consumer groups, retry/DLQ, transactional outbox
- Add stream topology table, protocol comparison table, why-not-SAGA explanation
- Add correlation-based tracing docs, GZip middleware note
- Rewrite services page with publish/consume relationships and key behaviors
- Fix README: SAGA → choreography, update docs links to custom domain

## Changed pages
- `architecture.md` — major rewrite with patterns, stream mechanics, event flow diagrams
- `services.md` — rewritten with stream relationships and service behaviors
- `monitoring.md` — added correlation/tracing section, GZip note
- `getting-started.md` — added "try it yourself" walkthrough
- `index.md` — updated highlights
- `README.md` — fixed pattern name, updated docs URLs