### PR TITLE
Add multi-arch Docker CI/CD and polish docs

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,56 @@
+name: Build Docker Images
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: orders-service
+            context: .
+            dockerfile: orders/Dockerfile
+            target: production
+          - name: delivery-service
+            context: .
+            dockerfile: delivery/Dockerfile
+            target: production
+          - name: notifications-service
+            context: .
+            dockerfile: notifications/Dockerfile
+            target: production
+          - name: simulator-service
+            context: .
+            dockerfile: simulator/Dockerfile
+          - name: frontend-service
+            context: ./frontend
+            dockerfile: frontend/Dockerfile
+            build-args: VITE_ENV=production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: false
+          platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.target || '' }}
+          build-args: ${{ matrix.build-args || '' }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,84 @@
+name: Publish Docker Images
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    environment: docker hub
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: orders-service
+            context: .
+            dockerfile: orders/Dockerfile
+            target: production
+          - name: delivery-service
+            context: .
+            dockerfile: delivery/Dockerfile
+            target: production
+          - name: notifications-service
+            context: .
+            dockerfile: notifications/Dockerfile
+            target: production
+          - name: simulator-service
+            context: .
+            dockerfile: simulator/Dockerfile
+          - name: frontend-service
+            context: ./frontend
+            dockerfile: frontend/Dockerfile
+            build-args: VITE_ENV=production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            kkaarroollm/${{ matrix.name }}
+            ghcr.io/kkaarroollm/${{ matrix.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.target || '' }}
+          build-args: ${{ matrix.build-args || '' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,21 @@
 # Architecture
 
+## Design Patterns at a Glance
+
+| Pattern | Where | Why |
+|---------|-------|-----|
+| **Event-Driven Choreography** | Inter-service communication | No central orchestrator -- services react independently to domain events |
+| **Consumer Groups** | Redis Streams consumers | Load-balanced message distribution across pod replicas |
+| **Dead-Letter Queue** | Stream consumer retry logic | Isolates poison messages after 3 failed attempts |
+| **Envelope Pattern** | All stream messages | Correlation ID propagation for distributed tracing without Jaeger/Zipkin |
+| **Repository Pattern** | `shared/db/repository.py` | Generic async CRUD abstraction over MongoDB with type safety |
+| **Transaction Manager** | `shared/db/mongo.py` | Context-managed sessions for atomic multi-document operations |
+| **Strategy Pattern** | Simulator service | Pluggable simulation strategies per entity type (order vs delivery) |
+| **API Gateway** | NGINX reverse proxy | Single entry point with rate limiting, WebSocket upgrade, security headers |
+| **Write-Then-Publish** | Order creation flow | Avoids dual-write problem -- event published only after DB transaction commits |
+
+---
+
 ## Design Patterns & Principles
 
 ### Event-Driven Choreography

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,30 @@
 # Deployment
 
+## Docker Images
+
+All application images are built for **linux/amd64** and **linux/arm64** (Raspberry Pi compatible).
+
+### Registries
+
+Images are published to both Docker Hub and GitHub Container Registry on every release:
+
+| Service | Docker Hub | GHCR |
+|---------|-----------|------|
+| Orders | `kkaarroollm/orders-service` | `ghcr.io/kkaarroollm/orders-service` |
+| Delivery | `kkaarroollm/delivery-service` | `ghcr.io/kkaarroollm/delivery-service` |
+| Notifications | `kkaarroollm/notifications-service` | `ghcr.io/kkaarroollm/notifications-service` |
+| Simulator | `kkaarroollm/simulator-service` | `ghcr.io/kkaarroollm/simulator-service` |
+| Frontend | `kkaarroollm/frontend-service` | `ghcr.io/kkaarroollm/frontend-service` |
+
+Tags follow semver: `:0.1.0`, `:0.2.0`, etc. The `:latest` tag always points to the most recent release.
+
+### CI/CD Pipeline
+
+- **On PR / push to master**: all 5 images are built for both architectures (no push) to catch build failures early
+- **On GitHub release**: images are built, tagged with the release version, and pushed to both registries
+
+---
+
 ## Docker Compose
 
 The `docker-compose.yaml` defines the full development stack: application services, databases, monitoring, and reverse proxy.
@@ -112,3 +137,25 @@ On first install, three Jobs run automatically:
 ServiceMonitors are defined for orders, delivery, and notifications services. Grafana dashboards are provisioned via ConfigMaps with the `grafana_dashboard: "1"` label (auto-discovered by the sidecar).
 
 Loki is configured as an additional Grafana datasource in `values.yaml`.
+
+---
+
+## Raspberry Pi Deployment
+
+All images are built for `linux/arm64`, so the full stack runs on a Raspberry Pi 4 or 5.
+
+### Resource Estimates
+
+| Stack | RAM | Disk |
+|-------|-----|------|
+| App only (5 services + MongoDB + Redis + NGINX) | ~1 GB | ~2 GB |
+| App + monitoring (Prometheus, Grafana, Loki, Promtail) | ~2-3 GB | ~5-10 GB |
+
+The retention limits (Prometheus 3 days / 256 MB, Loki 72 hours) keep disk usage bounded over time.
+
+### Tips
+
+- A Raspberry Pi 4 with **4 GB RAM** can run the full stack including monitoring
+- Use `DEPLOY_ENV=prod` for production-grade passwords
+- Consider reducing `replicaCount` to 1 in Helm values for single-node clusters
+- Cloudflare Tunnel works well for exposing the cluster without port forwarding


### PR DESCRIPTION
## Summary
- Add `docker-build.yaml` workflow: validates all 5 service images build for amd64+arm64 on every PR/push
- Add `docker-publish.yaml` workflow: publishes images to Docker Hub and GHCR on GitHub release (semver tags + latest)
- Add design patterns summary table to architecture docs
- Add Docker registry info and Raspberry Pi deployment notes to deployment docs

## Setup required
- Add Docker Hub secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (Settings → Secrets → Actions)
- Create a `docker hub` environment in repo settings

## Test plan
- [ ] Docker build workflow triggers on this PR and builds all 5 images
- [ ] After merge + release creation, publish workflow pushes to Docker Hub + GHCR
- [ ] Docs build without Sphinx warnings