### PR TITLE
Add idempotency keys, tracing and lag-based autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Events are versioned classes in `shared/events`; the class owns its stream and w
 | Duplicate deliveries | Inbox: event id recorded in the same transaction as the write |
 | Poison messages | 3 retries, then the `dead-letters` stream |
 | Dead consumers | Readiness fails and the process exits, so Kubernetes restarts it |
-| Unbounded growth | `MAXLEN` on every stream, TTL on inbox records |
+| Unbounded growth | `MAXLEN` on every stream, TTL on inbox and idempotency records |
+| Duplicate orders | `Idempotency-Key`: retry returns the original result |
 
 ## Quick Start
 

--- a/charts/orders-project/templates/keda-scaledobjects.yaml
+++ b/charts/orders-project/templates/keda-scaledobjects.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.keda.enabled }}
+{{- /*
+Scale consumers on stream lag, not CPU. A backlog is the signal that matters:
+these services are IO-bound, so they can be far behind while barely using a
+core. Requires KEDA to be installed in the cluster.
+*/ -}}
+{{- range .Values.keda.consumers }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ $.Values.global.fullnameOverride }}-{{ .name }}-scaler
+  namespace: {{ $.Release.Namespace }}
+spec:
+  scaleTargetRef:
+    name: {{ $.Values.global.fullnameOverride }}-{{ .name }}
+  minReplicaCount: {{ .minReplicas }}
+  maxReplicaCount: {{ .maxReplicas }}
+  pollingInterval: 15
+  # Long enough that a burst does not immediately scale back down mid-backlog.
+  cooldownPeriod: 120
+  triggers:
+    {{- range .streams }}
+    - type: redis-streams
+      metadata:
+        address: {{ $.Values.global.fullnameOverride }}-redis-svc:6379
+        stream: {{ .stream }}
+        consumerGroup: {{ .group }}
+        lagCount: {{ .lagCount | quote }}
+        activationLagCount: {{ .activationLagCount | default "1" | quote }}
+      authenticationRef:
+        name: {{ $.Values.global.fullnameOverride }}-redis-auth-trigger
+    {{- end }}
+{{- end }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ .Values.global.fullnameOverride }}-redis-auth-trigger
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretTargetRef:
+    - parameter: password
+      name: {{ .Values.global.fullnameOverride }}-redis-auth
+      key: REDIS_PASSWORD
+{{- end }}

--- a/charts/orders-project/values.yaml
+++ b/charts/orders-project/values.yaml
@@ -92,3 +92,25 @@ loki:
 promtail:
   enabled: true
 
+
+# Scale stream consumers on backlog rather than CPU. Off by default: it needs
+# KEDA installed in the cluster.
+keda:
+  enabled: false
+  consumers:
+    - name: orders
+      minReplicas: 1
+      maxReplicas: 4
+      streams:
+        - stream: order-status-stream
+          group: orders-group
+          lagCount: 50
+    - name: delivery
+      minReplicas: 1
+      maxReplicas: 4
+      streams:
+        - stream: orders-stream
+          group: delivery-group
+          lagCount: 50
+    # notifications is deliberately absent: it is bound by how many SSE streams
+    # it holds, not by backlog, so lag is the wrong signal for it.

--- a/delivery/pyproject.toml
+++ b/delivery/pyproject.toml
@@ -5,7 +5,7 @@ description = "Delivery microservice for food delivery platform"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "shared[mongo,web]",
+    "shared[mongo,web,otel]",
 ]
 
 [tool.uv.sources]

--- a/delivery/src/lifespan.py
+++ b/delivery/src/lifespan.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from shared.db.inbox import MongoInbox
 from shared.logging import setup_logging
 from shared.redis.publisher import StreamProducer
+from shared.tracing import setup_tracing
 
 from src.databases import close_databases, connect_databases
 from src.repository import DeliveryRepository
@@ -16,6 +17,7 @@ from src.streams import setup_streams, stop_streams
 
 async def startup(app: FastAPI) -> None:
     setup_logging()
+    setup_tracing("delivery-service")
     mongo_client, database, redis_client = await connect_databases()
 
     delivery_repo = DeliveryRepository(

--- a/delivery/src/main.py
+++ b/delivery/src/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from prometheus_client import make_asgi_app
 from shared.http_metrics import PrometheusMiddleware
+from shared.tracing import instrument_app
 
 from src.lifespan import startup, teardown
 from src.routes import router
@@ -27,5 +28,7 @@ app = FastAPI(
 app.include_router(router)
 
 app.mount("/metrics", make_asgi_app())
+
+instrument_app(app)
 
 app.add_middleware(PrometheusMiddleware)  # ty: ignore[invalid-argument-type]

--- a/docs/design.md
+++ b/docs/design.md
@@ -148,13 +148,37 @@ Honest limitations, rather than a feature list:
 - **No payments**, which is exactly why no saga is needed yet.
 - **Menu reads hit MongoDB** on every request. An obvious cache, deliberately not
   built until there is load to justify invalidation.
-- **Correlation IDs, not traces.** Every log line carries an id and Loki joins
-  them. Real spans need OpenTelemetry and a backend to hold them.
+- **Tracing needs a collector.** Spans are produced and propagate across
+  streams, but nothing collects them unless `OTEL_EXPORTER_OTLP_ENDPOINT` points
+  somewhere. Correlation IDs in Loki remain the default way to follow an order.
 - **The dead-letter stream has no replay tool.** Inspection is manual.
 
 ## Observability
 
-Prometheus scrapes per-service RED metrics and per-stream counters. Grafana
-dashboards ship in the chart. Loki holds structured logs, each line carrying the
-`correlation_id` that follows an event across every service — which is how a
-single order is traced end to end without a tracing system.
+Prometheus scrapes per-service RED metrics, per-stream counters and
+`stream_group_lag`. Grafana dashboards ship in the chart. Loki holds structured
+logs, each line carrying the `correlation_id` that follows an event across every
+service — which is how a single order is followed end to end without a tracing
+backend.
+
+Tracing is available but optional. It turns on only when
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set, and the `otel` extra can be left
+uninstalled entirely. The part that automatic instrumentation cannot do for you
+is the stream hop: a publisher writes W3C trace context into the message
+envelope and the consumer continues that trace, so an order and the delivery it
+causes land in **one** trace rather than several disconnected ones.
+
+## Scaling on backlog
+
+Stream consumers scale on lag, not CPU. They are IO-bound, so a service can be
+thousands of messages behind while barely touching a core — CPU would never
+trigger. KEDA `ScaledObject`s ship in the chart, disabled by default since they
+need KEDA installed:
+
+```yaml
+keda:
+  enabled: true
+```
+
+Notifications is deliberately excluded: it is bound by how many SSE streams it
+holds open, so backlog is the wrong signal for it.

--- a/docs/design.md
+++ b/docs/design.md
@@ -100,6 +100,11 @@ so a replayed or late event matches no document and is dropped.
 **Poison messages are quarantined.** Three failures, then the `dead-letters`
 stream, with the original payload and error preserved.
 
+**Retries do not double-order.** `POST /orders` accepts an `Idempotency-Key`.
+The key is reserved inside the order's transaction, so it is only consumed if
+the order is actually created — a rejected order leaves the key usable, and a
+client that times out and retries gets its original result back.
+
 The relay uses a change stream for latency and a 30-second sweep for
 correctness. The sweep alone is sufficient — it covers a relay that was down, a
 publish that failed, and a resume token that aged out of the oplog — so the
@@ -127,7 +132,8 @@ resumes rather than stranding orders.
 
 1. **Redis memory** — streams are trimmed with `MAXLEN`, but retention is still
    RAM. Trimming under a stalled consumer silently drops events, so consumer lag
-   is the metric to alert on.
+   is the metric to alert on: every bus reports `stream_group_lag` per stream
+   and group, which rises well before trimming starts discarding a backlog.
 2. **MongoDB writes** — a single replica set primary takes every write. Read
    replicas help reads; write scaling needs sharding.
 3. **The stateful edge** — SSE streams are long-lived connections, so

--- a/notifications/pyproject.toml
+++ b/notifications/pyproject.toml
@@ -5,7 +5,7 @@ description = "Notifications microservice for food delivery platform"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "shared[web]",
+    "shared[web,otel]",
 ]
 
 [tool.uv.sources]

--- a/notifications/src/lifespan.py
+++ b/notifications/src/lifespan.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from shared.logging import setup_logging
 from shared.redis.connection import connect_redis
 from shared.redis.publisher import StreamProducer
+from shared.tracing import setup_tracing
 
 from src.repository import NotificationRepository
 from src.service import NotificationService, StatusPushFanout
@@ -16,6 +17,7 @@ from src.streams import setup_streams, stop_streams
 
 async def startup(app: FastAPI) -> None:
     setup_logging()
+    setup_tracing("notifications-service")
     redis_client = await connect_redis(settings.redis_url)
 
     notification_repo = NotificationRepository(redis_client)

--- a/notifications/src/main.py
+++ b/notifications/src/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from prometheus_client import make_asgi_app
 from shared.http_metrics import GZipMiddleware, PrometheusMiddleware
+from shared.tracing import instrument_app
 
 from src.lifespan import startup, teardown
 from src.routes import router
@@ -58,6 +59,8 @@ async def order_tracking(order_id: str) -> StreamingResponse:
 app.include_router(router)
 
 app.mount("/metrics", make_asgi_app())
+
+instrument_app(app)
 
 app.add_middleware(PrometheusMiddleware)  # ty: ignore[invalid-argument-type]
 app.add_middleware(GZipMiddleware)  # ty: ignore[invalid-argument-type]

--- a/orders/pyproject.toml
+++ b/orders/pyproject.toml
@@ -5,7 +5,7 @@ description = "Orders microservice for food delivery platform"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "shared[mongo,web]",
+    "shared[mongo,web,otel]",
 ]
 
 [tool.uv.sources]

--- a/orders/src/lifespan.py
+++ b/orders/src/lifespan.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 from fastapi import FastAPI
+from shared.db.idempotency import IdempotencyStore
 from shared.db.outbox import MongoOutbox, OutboxRelay
 from shared.logging import setup_logging
 from shared.redis.event_bus import terminate_on_failure
@@ -46,6 +47,11 @@ async def startup(app: FastAPI) -> None:
     await outbox.ensure_indexes()
     relay = OutboxRelay(outbox=outbox, producer=publisher)
 
+    idempotency = IdempotencyStore(
+        collection=database.get_collection(settings.mongo_collection_idempotency)
+    )
+    await idempotency.ensure_indexes()
+
     state = AppState(
         mongo_client=mongo_client,
         database=database,
@@ -57,6 +63,7 @@ async def startup(app: FastAPI) -> None:
             order_repo=order_repo,
             menu_repo=menu_repo,
             outbox=outbox,
+            idempotency=idempotency,
             mongo_client=mongo_client,
         ),
         outbox_relay=relay,

--- a/orders/src/lifespan.py
+++ b/orders/src/lifespan.py
@@ -8,6 +8,7 @@ from shared.db.outbox import MongoOutbox, OutboxRelay
 from shared.logging import setup_logging
 from shared.redis.event_bus import terminate_on_failure
 from shared.redis.publisher import StreamProducer
+from shared.tracing import setup_tracing
 
 from src.databases import close_databases, connect_databases
 from src.repositories.menu_item_repo import MenuItemRepository
@@ -32,6 +33,7 @@ def _on_relay_stopped(task: asyncio.Task[None]) -> None:
 
 async def startup(app: FastAPI) -> None:
     setup_logging()
+    setup_tracing("orders-service")
     mongo_client, database, redis_client = await connect_databases()
 
     menu_repo = MenuItemRepository(

--- a/orders/src/main.py
+++ b/orders/src/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import make_asgi_app
 from shared.http_metrics import GZipMiddleware, PrometheusMiddleware
+from shared.tracing import instrument_app
 
 from src.lifespan import startup, teardown
 from src.routes import router
@@ -32,6 +33,8 @@ app: FastAPI = FastAPI(
 app.include_router(router)
 
 app.mount("/metrics", make_asgi_app())
+
+instrument_app(app)
 
 app.add_middleware(PrometheusMiddleware)  # ty: ignore[invalid-argument-type]
 app.add_middleware(GZipMiddleware)  # ty: ignore[invalid-argument-type]

--- a/orders/src/routes/orders.py
+++ b/orders/src/routes/orders.py
@@ -1,9 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 
 from src.dependencies import get_order_service
 from src.responses import OrderResponse
 from src.schemas import OrderSchema
-from src.services.order_service import OrderService
+from src.services.order_service import OrderService, RequestInProgressError
 
 router = APIRouter(prefix="/orders", tags=["orders"])
 
@@ -11,9 +13,23 @@ router = APIRouter(prefix="/orders", tags=["orders"])
 @router.post("", response_model=OrderResponse, status_code=status.HTTP_201_CREATED)
 async def create_order(
     order_data: OrderSchema,
+    idempotency_key: Annotated[
+        str | None,
+        Header(
+            alias="Idempotency-Key",
+            description="Retrying with the same key returns the original result instead of ordering twice.",
+        ),
+    ] = None,
     order_service: OrderService = Depends(get_order_service),
 ) -> OrderResponse:
-    response = await order_service.create_order_with_stock_check(order_data)
+    try:
+        response = await order_service.create_order_with_stock_check(order_data, idempotency_key)
+    except RequestInProgressError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A request with this Idempotency-Key is still in progress",
+        ) from None
+
     if not response.success:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=response.message)
     return response

--- a/orders/src/services/order_service.py
+++ b/orders/src/services/order_service.py
@@ -2,6 +2,8 @@ import logging
 from decimal import Decimal
 
 from pymongo import AsyncMongoClient
+from pymongo.errors import DuplicateKeyError
+from shared.db.idempotency import IdempotencyStore
 from shared.db.outbox import MongoOutbox
 from shared.events.order import (
     OrderCreated,
@@ -30,25 +32,45 @@ class OrderRejectedError(Exception):
         self.message = message
 
 
+class RequestInProgressError(Exception):
+    """An idempotency key is reserved but its response is not stored yet.
+
+    Either another request is mid-flight, or one crashed between committing and
+    recording its response. Replaying is unsafe, so the caller retries later.
+    """
+
+
 class OrderService(TransactionServiceMixin):
     def __init__(
         self,
         order_repo: OrderRepository,
         menu_repo: MenuItemRepository,
         outbox: MongoOutbox,
+        idempotency: IdempotencyStore,
         mongo_client: AsyncMongoClient,
     ) -> None:
         super().__init__(mongo_client)
         self._order_repo = order_repo
         self._menu_repo = menu_repo
         self._outbox = outbox
+        self._idempotency = idempotency
 
     async def get(self, order_id: str) -> OrderSchema | None:
         return await self._order_repo.get_by_id(order_id, session=None)
 
-    async def create_order_with_stock_check(self, order_data: OrderSchema) -> OrderResponse:
+    async def create_order_with_stock_check(
+        self, order_data: OrderSchema, idempotency_key: str | None = None
+    ) -> OrderResponse:
+        if idempotency_key and (replay := await self._replay(idempotency_key)):
+            return replay
+
         try:
             async with self.transaction() as session:
+                if idempotency_key:
+                    # Reserved inside the transaction, so the key is only taken
+                    # if the order it stands for is actually created.
+                    await self._idempotency.reserve(idempotency_key, session)
+
                 total_price = Decimal("0.00")
 
                 for item in order_data.items:
@@ -87,8 +109,25 @@ class OrderService(TransactionServiceMixin):
         except OrderRejectedError as rejected:
             logging.info("Rejected order: %s", rejected.message)
             return OrderResponse(order=order_data, success=False, message=rejected.message)
+        except DuplicateKeyError:
+            # A concurrent request won the key; return whatever it produced.
+            if idempotency_key and (replay := await self._replay(idempotency_key)):
+                return replay
+            raise RequestInProgressError from None
 
-        return OrderResponse(order=order_data, success=True)
+        response = OrderResponse(order=order_data, success=True)
+        if idempotency_key:
+            await self._idempotency.complete(idempotency_key, response.model_dump(mode="json"))
+        return response
+
+    async def _replay(self, idempotency_key: str) -> OrderResponse | None:
+        record = await self._idempotency.find(idempotency_key)
+        if record is None:
+            return None
+        if record.get("response") is None:
+            raise RequestInProgressError
+        logging.info("Replaying stored response for idempotency key %s", idempotency_key)
+        return OrderResponse.model_validate(record["response"])
 
     async def update_order_status(self, order_id: str, new_status: OrderStatus) -> OrderResponse:
         async with self.transaction() as session:

--- a/orders/src/settings.py
+++ b/orders/src/settings.py
@@ -11,6 +11,7 @@ class Settings(BaseServiceSettings):
 
     mongo_collection_orders: str = "orders"
     mongo_collection_outbox: str = "outbox"
+    mongo_collection_idempotency: str = "idempotency_keys"
     mongo_collection_menu_items: str = "menu_items"
 
     # Stream names live on the event classes in `shared.events`.

--- a/orders/tests/test_order_service.py
+++ b/orders/tests/test_order_service.py
@@ -27,6 +27,13 @@ def outbox():
 
 
 @pytest.fixture
+def idempotency():
+    store = AsyncMock()
+    store.find.return_value = None
+    return store
+
+
+@pytest.fixture
 def mongo_client():
     client = MagicMock()
     session = AsyncMock()
@@ -39,11 +46,12 @@ def mongo_client():
 
 
 @pytest.fixture
-def service(order_repo, menu_repo, outbox, mongo_client):
+def service(order_repo, menu_repo, outbox, idempotency, mongo_client):
     return OrderService(
         order_repo=order_repo,
         menu_repo=menu_repo,
         outbox=outbox,
+        idempotency=idempotency,
         mongo_client=mongo_client,
     )
 

--- a/orders/tests/test_outbox_integration.py
+++ b/orders/tests/test_outbox_integration.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from pymongo import AsyncMongoClient
+from shared.db.idempotency import IdempotencyStore
 from shared.db.outbox import MongoOutbox, OutboxRelay
 
 from src.repositories.menu_item_repo import MenuItemRepository
@@ -25,7 +26,7 @@ pytestmark = pytest.mark.skipif(not MONGO_URL, reason="INTEGRATION_MONGO_URL not
 async def database():
     client: AsyncMongoClient = AsyncMongoClient(MONGO_URL)
     db = client["orders-integration-test"]
-    for name in ("orders", "outbox", "menu_items"):
+    for name in ("orders", "outbox", "menu_items", "idempotency_keys"):
         await db[name].delete_many({})
     yield db
     await client.close()
@@ -47,11 +48,19 @@ async def outbox(database):
 
 
 @pytest.fixture
-async def service(database, outbox):
+async def idempotency(database):
+    store = IdempotencyStore(collection=database["idempotency_keys"])
+    await store.ensure_indexes()
+    return store
+
+
+@pytest.fixture
+async def service(database, outbox, idempotency):
     return OrderService(
         order_repo=OrderRepository(collection=database["orders"]),
         menu_repo=MenuItemRepository(collection=database["menu_items"]),
         outbox=outbox,
+        idempotency=idempotency,
         mongo_client=database.client,
     )
 
@@ -120,6 +129,36 @@ async def test_skipping_a_status_is_rejected(service, database, menu_item_id):
 
     assert not (await service.update_order_status(order_id, OrderStatus.OUT_FOR_DELIVERY)).success
     assert (await database["orders"].find_one({}))["status"] == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_retry_with_the_same_key_creates_one_order(service, database, menu_item_id):
+    """A client that times out and retries must not order twice."""
+    first = await service.create_order_with_stock_check(_order(menu_item_id), "key-abc")
+    second = await service.create_order_with_stock_check(_order(menu_item_id), "key-abc")
+
+    assert first.order.id == second.order.id
+    assert await database["orders"].count_documents({}) == 1
+    assert (await database["menu_items"].find_one({}))["stock"] == 4
+
+
+@pytest.mark.asyncio
+async def test_different_keys_create_different_orders(service, database, menu_item_id):
+    await service.create_order_with_stock_check(_order(menu_item_id), "key-abc")
+    await service.create_order_with_stock_check(_order(menu_item_id), "key-xyz")
+
+    assert await database["orders"].count_documents({}) == 2
+
+
+@pytest.mark.asyncio
+async def test_rejected_order_does_not_burn_its_key(service, database, menu_item_id):
+    """The reservation rolls back with the order, so the key stays usable."""
+    rejected = await service.create_order_with_stock_check(_order(menu_item_id, quantity=99), "key-abc")
+    assert rejected.success is False
+    assert await database["idempotency_keys"].count_documents({}) == 0
+
+    accepted = await service.create_order_with_stock_check(_order(menu_item_id), "key-abc")
+    assert accepted.success is True
 
 
 @pytest.mark.asyncio

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -20,6 +20,14 @@ web = [
     "fastapi[standard]==0.115.11",
     "starlette>=0.36",
 ]
+# HTTP exporter rather than gRPC: no grpcio to build on arm64.
+otel = [
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-pymongo>=0.48b0",
+    "opentelemetry-instrumentation-redis>=0.48b0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/shared"]

--- a/shared/src/shared/db/idempotency.py
+++ b/shared/src/shared/db/idempotency.py
@@ -1,0 +1,39 @@
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pymongo.asynchronous.client_session import AsyncClientSession
+from pymongo.asynchronous.collection import AsyncCollection
+
+_RETENTION = timedelta(hours=24)
+
+
+class IdempotencyStore:
+    """Makes a retried request return its original result instead of acting twice.
+
+    A client that times out and retries `POST /orders` would otherwise create a
+    second order. The key is reserved inside the order's own transaction, so the
+    reservation and the order commit together or not at all.
+    """
+
+    def __init__(self, collection: AsyncCollection) -> None:
+        self._collection = collection
+
+    async def ensure_indexes(self) -> None:
+        await self._collection.create_index("key", unique=True, name="uniq_key")
+        await self._collection.create_index("expires_at", expireAfterSeconds=0, name="ttl_expires_at")
+
+    async def reserve(self, key: str, session: AsyncClientSession) -> None:
+        """Claim a key. Raises `DuplicateKeyError` if it is already taken."""
+        now = datetime.now(UTC)
+        await self._collection.insert_one(
+            {"key": key, "response": None, "created_at": now, "expires_at": now + _RETENTION},
+            session=session,
+        )
+
+    async def complete(self, key: str, response: dict[str, Any]) -> None:
+        await self._collection.update_one({"key": key}, {"$set": {"response": response}})
+        logging.debug("Stored idempotent response for key %s", key)
+
+    async def find(self, key: str) -> dict[str, Any] | None:
+        return await self._collection.find_one({"key": key})

--- a/shared/src/shared/redis/consumer.py
+++ b/shared/src/shared/redis/consumer.py
@@ -10,6 +10,7 @@ from redis.asyncio import Redis
 from shared.events.base import DomainEvent
 from shared.redis.envelope import MessageEnvelope
 from shared.redis.metrics import STREAM_DLQ_TOTAL, STREAM_MESSAGE_DURATION, STREAM_MESSAGES_TOTAL
+from shared.tracing import consumer_span
 
 TEvent = TypeVar("TEvent", bound=DomainEvent)
 
@@ -129,7 +130,19 @@ class StreamConsumer:
 
             event = route.event.model_validate(envelope.payload)
             start = time.monotonic()
-            await route.handler(event)
+            with consumer_span(
+                f"{self._stream} process",
+                envelope.traceparent,
+                **{
+                    "messaging.system": "redis_streams",
+                    "messaging.destination.name": self._stream,
+                    "messaging.consumer.group.name": self._group,
+                    "messaging.message.id": str(message_id),
+                    "event.type": envelope.event_type,
+                    "correlation.id": correlation_id,
+                },
+            ):
+                await route.handler(event)
             duration = time.monotonic() - start
 
             if not self._noack:

--- a/shared/src/shared/redis/envelope.py
+++ b/shared/src/shared/redis/envelope.py
@@ -12,5 +12,8 @@ class MessageEnvelope(BaseModel, Generic[T]):
     event_type: str
     correlation_id: str = ""
     source: str = ""
+    # W3C trace context, so a consumer can continue the producer's trace across
+    # the stream. Empty when tracing is off.
+    traceparent: str = ""
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     payload: dict[str, Any] = Field(default_factory=dict)

--- a/shared/src/shared/redis/event_bus.py
+++ b/shared/src/shared/redis/event_bus.py
@@ -12,8 +12,11 @@ from redis.asyncio import Redis
 
 from shared.events.base import DomainEvent
 from shared.redis.consumer import Route, StreamConsumer
+from shared.redis.metrics import STREAM_GROUP_LAG
 
 T = TypeVar("T", bound=DomainEvent)
+
+_LAG_INTERVAL_SECONDS = 15.0
 
 ConsumerFailureHandler = Callable[[str, BaseException], None]
 
@@ -91,11 +94,34 @@ class EventBus:
             task.add_done_callback(self._on_task_done)
             self._tasks.append(task)
 
+        lag_task = asyncio.create_task(self._report_lag())
+        lag_task.add_done_callback(self._on_task_done)
+        self._tasks.append(lag_task)
+
         logging.info(
             "EventBus started: %d stream consumer(s) in group '%s'",
-            len(self._tasks),
+            len(self._tasks) - 1,
             self._group,
         )
+
+    async def _report_lag(self) -> None:
+        """Publish per-group lag.
+
+        Streams are trimmed by `MAXLEN`, so a consumer that falls far enough
+        behind has its backlog silently discarded. Lag is the signal that
+        happens *before* that, which makes it the number worth alerting on.
+        """
+        while True:
+            for stream in self._routes:
+                try:
+                    for group in await self._redis.xinfo_groups(stream):
+                        if group.get("name") != self._group:
+                            continue
+                        if (lag := group.get("lag")) is not None:
+                            STREAM_GROUP_LAG.labels(stream=stream, group=self._group).set(lag)
+                except Exception as error:  # stream may not exist yet
+                    logging.debug("Could not read lag for `%s`: %s", stream, error)
+            await asyncio.sleep(_LAG_INTERVAL_SECONDS)
 
     def _on_task_done(self, task: asyncio.Task[None]) -> None:
         """`listen()` loops forever, so any completion at all is a failure."""

--- a/shared/src/shared/redis/metrics.py
+++ b/shared/src/shared/redis/metrics.py
@@ -1,4 +1,10 @@
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
+
+STREAM_GROUP_LAG = Gauge(
+    "stream_group_lag",
+    "Entries added to the stream that this group has not yet delivered",
+    ["stream", "group"],
+)
 
 STREAM_MESSAGES_TOTAL = Counter(
     "stream_messages_processed_total",

--- a/shared/src/shared/redis/publisher.py
+++ b/shared/src/shared/redis/publisher.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from redis.asyncio import Redis
 
 from shared.events.base import DomainEvent
+from shared.tracing import current_traceparent
 
 TMessage = TypeVar("TMessage", bound=BaseModel)
 
@@ -59,6 +60,7 @@ class StreamProducer(Generic[TMessage]):
             "event_type": event_type,
             "correlation_id": correlation_id,
             "source": self._source,
+            "traceparent": current_traceparent(),
             "timestamp": time.time(),
             "payload": data,
         }

--- a/shared/src/shared/tracing.py
+++ b/shared/src/shared/tracing.py
@@ -1,0 +1,84 @@
+"""OpenTelemetry, kept optional.
+
+Tracing is off unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set, and the `otel`
+extra may not be installed at all, so every helper here degrades to a no-op
+rather than forcing the dependency on services that do not want it.
+"""
+
+import logging
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+try:
+    from opentelemetry import propagate, trace
+    from opentelemetry.trace import SpanKind
+
+    _OTEL_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on the `otel` extra
+    _OTEL_AVAILABLE = False
+
+_TRACEPARENT = "traceparent"
+
+
+def setup_tracing(service_name: str) -> None:
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        logging.info("OTEL_EXPORTER_OTLP_ENDPOINT unset, tracing disabled")
+        return
+    if not _OTEL_AVAILABLE:
+        logging.warning("Tracing requested but the `otel` extra is not installed")
+        return
+
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.pymongo import PymongoInstrumentor
+    from opentelemetry.instrumentation.redis import RedisInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    PymongoInstrumentor().instrument()
+    RedisInstrumentor().instrument()
+    logging.info("Tracing enabled for `%s` exporting to %s", service_name, endpoint)
+
+
+def instrument_app(app: Any) -> None:
+    """Instrument a FastAPI app, if tracing is on."""
+    if not (_OTEL_AVAILABLE and os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")):
+        return
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+    FastAPIInstrumentor.instrument_app(app)
+
+
+def current_traceparent() -> str:
+    """W3C trace context for the active span, or "" when tracing is off."""
+    if not _OTEL_AVAILABLE:
+        return ""
+    carrier: dict[str, str] = {}
+    propagate.inject(carrier)
+    return carrier.get(_TRACEPARENT, "")
+
+
+@contextmanager
+def consumer_span(name: str, traceparent: str, **attributes: str) -> Iterator[None]:
+    """Continue the producer's trace while handling a message.
+
+    Without this each service produces its own disconnected trace: the stream
+    is an async boundary that automatic instrumentation cannot see across.
+    """
+    if not _OTEL_AVAILABLE:
+        yield
+        return
+
+    parent = propagate.extract({_TRACEPARENT: traceparent}) if traceparent else None
+    tracer = trace.get_tracer("shared.redis.consumer")
+    with tracer.start_as_current_span(name, context=parent, kind=SpanKind.CONSUMER) as span:
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+        yield

--- a/shared/tests/test_tracing.py
+++ b/shared/tests/test_tracing.py
@@ -1,0 +1,97 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from shared.events.order import OrderCreated
+from shared.redis.consumer import Route, StreamConsumer
+from shared.redis.publisher import StreamProducer
+from shared.tracing import consumer_span
+
+
+# A TracerProvider can only be installed once per process, so it is set here
+# rather than per test; each test just clears the exporter.
+_EXPORTER = InMemorySpanExporter()
+_PROVIDER = TracerProvider()
+_PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
+trace.set_tracer_provider(_PROVIDER)
+
+
+@pytest.fixture
+def spans():
+    _EXPORTER.clear()
+    return _EXPORTER
+
+
+@pytest.mark.asyncio
+async def test_publish_carries_trace_context(spans):
+    redis = AsyncMock()
+    producer: StreamProducer = StreamProducer(redis, source="orders-service")
+
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("create order"):
+        await producer.publish(OrderCreated(id="order123", status="confirmed"))
+
+    envelope = json.loads(redis.xadd.call_args.args[1]["data"])
+    assert envelope["traceparent"].startswith("00-")
+
+
+@pytest.mark.asyncio
+async def test_consumer_joins_the_producers_trace(spans):
+    """Producer and consumer must land in one trace, not two disconnected ones."""
+    redis = AsyncMock()
+    producer: StreamProducer = StreamProducer(redis, source="orders-service")
+
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("create order") as producer_span:
+        expected_trace_id = producer_span.get_span_context().trace_id
+        await producer.publish(OrderCreated(id="order123", status="confirmed"))
+
+    envelope = json.loads(redis.xadd.call_args.args[1]["data"])
+    with consumer_span("orders-stream process", envelope["traceparent"]):
+        pass
+
+    consumer = [span for span in spans.get_finished_spans() if span.name == "orders-stream process"]
+    assert len(consumer) == 1
+    assert consumer[0].context.trace_id == expected_trace_id
+
+
+@pytest.mark.asyncio
+async def test_handler_runs_inside_a_span(spans):
+    redis = AsyncMock()
+    handler = AsyncMock()
+    consumer = StreamConsumer(
+        redis=redis,
+        stream="orders-stream",
+        group="test-group",
+        consumer_name="test",
+        routes={OrderCreated.event_type: Route(OrderCreated, handler)},
+    )
+    message = {
+        "data": json.dumps(
+            {
+                "event_type": OrderCreated.event_type,
+                "correlation_id": "order123",
+                "traceparent": "",
+                "payload": {"id": "order123", "status": "confirmed"},
+            }
+        )
+    }
+
+    await consumer._process_message("1-1", message)
+
+    handler.assert_awaited_once()
+    names = [span.name for span in spans.get_finished_spans()]
+    assert "orders-stream process" in names
+
+
+def test_missing_traceparent_is_not_an_error(spans):
+    """Tracing is optional, so an untraced message must still be handled."""
+    with consumer_span("orders-stream process", ""):
+        pass
+
+    assert [span.name for span in spans.get_finished_spans()] == ["orders-stream process"]

--- a/uv.lock
+++ b/uv.lock
@@ -47,12 +47,69 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -81,11 +138,11 @@ name = "delivery"
 version = "0.1.0"
 source = { virtual = "delivery" }
 dependencies = [
-    { name = "shared", extra = ["mongo", "web"] },
+    { name = "shared", extra = ["mongo", "otel", "web"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "shared", extras = ["mongo", "web"], editable = "shared" }]
+requires-dist = [{ name = "shared", extras = ["mongo", "web", "otel"], editable = "shared" }]
 
 [[package]]
 name = "dnspython"
@@ -249,6 +306,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/e2/dfa19a4b260b8ab3581b7484dcb80c09b25324f4daa6b6ae1c7640d1607a/fastar-0.8.0-cp314-cp314t-win32.whl", hash = "sha256:187f61dc739afe45ac8e47ed7fd1adc45d52eac110cf27d579155720507d6fbe", size = 455767, upload-time = "2025-11-26T02:36:34.758Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/df65c72afc1297797b255f90c4778b5d6f1f0f80282a134d5ab610310ed9/fastar-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:40e9d763cf8bf85ce2fa256e010aa795c0fe3d3bd1326d5c3084e6ce7857127e", size = 489971, upload-time = "2025-11-26T02:36:22.081Z" },
     { url = "https://files.pythonhosted.org/packages/85/11/0aa8455af26f0ae89e42be67f3a874255ee5d7f0f026fc86e8d56f76b428/fastar-0.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e59673307b6a08210987059a2bdea2614fe26e3335d0e5d1a3d95f49a05b1418", size = 460467, upload-time = "2025-11-26T02:36:07.978Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -418,22 +487,188 @@ name = "notifications"
 version = "0.1.0"
 source = { virtual = "notifications" }
 dependencies = [
-    { name = "shared", extra = ["web"] },
+    { name = "shared", extra = ["otel", "web"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "shared", extras = ["web"], editable = "shared" }]
+requires-dist = [{ name = "shared", extras = ["web", "otel"], editable = "shared" }]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/83/8e8e83b7ac285281687c7be2fd305213ccccbb8c0a2dd4fb45a8ccaf12c7/opentelemetry_instrumentation_asgi-0.65b0.tar.gz", hash = "sha256:892bca67c56522ffa85a8a83cf934d7b50b3be2132e45cbee705825f0a5ba426", size = 26140, upload-time = "2026-07-16T15:25:54.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/9c/376962840b619d2d55fe8ee2285f8c70971c090e5fff614516fc654a6f3a/opentelemetry_instrumentation_asgi-0.65b0-py3-none-any.whl", hash = "sha256:3a845a8ebd1c4ef0d8263401e6545f5b219b2feee612090d50f578a87e71fd65", size = 15903, upload-time = "2026-07-16T15:24:57.198Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/b057f8196d06efdc1b50e3ff11fbc499a7d96b35c87f217eb7885542f4ea/opentelemetry_instrumentation_fastapi-0.65b0.tar.gz", hash = "sha256:10a3a95486036230413a58fe4fdf4a83fa6bba46918407e527476994bd92bd97", size = 26236, upload-time = "2026-07-16T15:26:05.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b0/c9b0300d33349ecc3dfd2362516eaffc44877e90970e6a52178ff953fec3/opentelemetry_instrumentation_fastapi-0.65b0-py3-none-any.whl", hash = "sha256:cda2610a0ec1b22d19886f33e4d861e9f5dbb886aeaa3a1263b47aff82c36943", size = 13261, upload-time = "2026-07-16T15:25:12.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-pymongo"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/06/73315a138049c5894bafa18569fd5c9949cf4c9a972ed7151d16900af49d/opentelemetry_instrumentation_pymongo-0.65b0.tar.gz", hash = "sha256:8a43f368f7dd101622d2b5929b0c12c4099a0c4a072284b86d18b75dfee10007", size = 11312, upload-time = "2026-07-16T15:26:14.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/46/a4c918ac6b778adf967fd8b65b714a565d76c61a31be3e86a18fffd69b2c/opentelemetry_instrumentation_pymongo-0.65b0-py3-none-any.whl", hash = "sha256:c714006d3075b0d9cd1a5e8091dce139cb58ee1fbc5a23d5c8f8576e9ae14e53", size = 10638, upload-time = "2026-07-16T15:25:25.302Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/e5/b369897a9ff902eb028f1f999c9f9a4602f0b30fe1e97298d2c15fe5b8b0/opentelemetry_instrumentation_redis-0.65b0.tar.gz", hash = "sha256:f16409f189092984ff922f26939e7be79509365f5c9d202308c13fddf1368147", size = 17218, upload-time = "2026-07-16T15:26:17.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/5b874bf8824e7cb995b22e1e61e1b5bc42810023d81612c44edbfd2c48a3/opentelemetry_instrumentation_redis-0.65b0-py3-none-any.whl", hash = "sha256:7d135f61db9d72416e1f382012fbc13de6f5e726491bebd0344a9c42a60e6769", size = 14658, upload-time = "2026-07-16T15:25:29.146Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
+]
 
 [[package]]
 name = "orders"
 version = "0.1.0"
 source = { virtual = "orders" }
 dependencies = [
-    { name = "shared", extra = ["mongo", "web"] },
+    { name = "shared", extra = ["mongo", "otel", "web"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "shared", extras = ["mongo", "web"], editable = "shared" }]
+requires-dist = [{ name = "shared", extras = ["mongo", "web", "otel"], editable = "shared" }]
 
 [[package]]
 name = "orders-project-workspace"
@@ -483,6 +718,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -685,6 +935,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -817,6 +1082,13 @@ dependencies = [
 mongo = [
     { name = "pymongo" },
 ]
+otel = [
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-pymongo" },
+    { name = "opentelemetry-instrumentation-redis" },
+    { name = "opentelemetry-sdk" },
+]
 web = [
     { name = "fastapi", extra = ["standard"] },
     { name = "starlette" },
@@ -825,6 +1097,11 @@ web = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.115.11" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-pymongo", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-redis", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pydantic-settings", specifier = ">=2.8" },
@@ -832,7 +1109,7 @@ requires-dist = [
     { name = "redis", specifier = "==5.2.1" },
     { name = "starlette", marker = "extra == 'web'", specifier = ">=0.36" },
 ]
-provides-extras = ["mongo", "web"]
+provides-extras = ["mongo", "web", "otel"]
 
 [[package]]
 name = "shellingham"
@@ -1076,4 +1353,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b0/c1f5a970721f06b85c0cd5142e0ff8fe067708abd779b0c4f4be7d61d09f/wrapt-2.3.0.tar.gz", hash = "sha256:681a2d0eefd721998f90642762b8e75c2159ec531b20ad5e437245ea7b06a107", size = 131509, upload-time = "2026-07-28T06:06:14.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/6e/0f88a072483e76b881e3fdcd6b6ffb4a5791002514fe541e72b1b73c859a/wrapt-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d3fb71e65b001adfc42684522eeccd9c21d8ba679945abc993439567b66e59f", size = 81960, upload-time = "2026-07-28T06:04:49.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ff/b7e2776e7c294075eb712cc9ef573d1b818f393006d09787262b8fc871c4/wrapt-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:51a7a4181c1295774812271fbcd7c909df372bc25579d4ed9eb875caaf0ae86f", size = 82435, upload-time = "2026-07-28T06:04:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/90/343bb5d0f1f9669bc252a6073f085b4abf862511bd5c9c9eaec754341f1d/wrapt-2.3.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9045917809c63fdf7abe3a2ceaed3d670b8ee4500ddd9291192d30aeb34467c5", size = 170350, upload-time = "2026-07-28T06:04:52.187Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f8/13b79a392930bd0dd6b86cbfbfe1c40944110456e1dc6d809e5c46ece904/wrapt-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54ca1d5573f69b5fe1d74f1f65799c68015e82f685efec9fd8cfa40a094c44d0", size = 170022, upload-time = "2026-07-28T06:04:53.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/4f1b6918f5290db959d6e0c07f77385d87cede29c39c9cf8f145e9c82954/wrapt-2.3.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:242b60c21e30866e6a2fa606c612b47c553fa60c0eaeeeb7797fb842ac0ce609", size = 161043, upload-time = "2026-07-28T06:04:54.936Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/45d3cf74414780bdff6d0380467e003f6eb0f028b6c9403db868dbc7209c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3f3d7ec0a51fbfe00d3aef047641ff2c58b25565b4717fc1f90e050be01cba8", size = 168576, upload-time = "2026-07-28T06:04:56.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/73/2fa58dd97f191c997755e2c6d569a68f0c433db4e4b36099bdd7227b6cac/wrapt-2.3.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:261f53870cd4fb2bf38f9f972c56c728fd224cb7c65721307de59d9e7e6741ae", size = 159140, upload-time = "2026-07-28T06:04:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a8/08a56e2000a8816d449dcbad8c8b081697acbbd490821ceca0f9d8e8d20c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8159ec0b0cb7608175eb150de94c19e34f4d47ac655f5ca9baf45df6b688ffd3", size = 169263, upload-time = "2026-07-28T06:04:59.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d4/354e1725e35a73b2af4fa70a3e024c7a5d1bf1802dfb862dcb668aae0253/wrapt-2.3.0-cp313-cp313-win32.whl", hash = "sha256:10461884b3014fbfc8eb7d09a93c5f246363e6711d9d881f95eb8c27fdef049f", size = 78241, upload-time = "2026-07-28T06:05:00.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7e/34c87fa2174848dfee820322aaa318bab08913998ccecc8d2f57b4ad4639/wrapt-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac870cc97b73bb00ac353329e9559a4bebc47c4c86792ed9b23b58c15b6ad838", size = 81113, upload-time = "2026-07-28T06:05:01.839Z" },
+    { url = "https://files.pythonhosted.org/packages/11/86/fcc9a530579e008c9478bb565a6cdfbfd33536660f069c8b91a6607c5050/wrapt-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:a65e8db2b4e90c2e7ade931086351c98ef420bf7a94ee08c95ac8a3cbbc43579", size = 80182, upload-time = "2026-07-28T06:05:03.152Z" },
+    { url = "https://files.pythonhosted.org/packages/96/50/3864848b95b28ef73e17551fc8dccbff2628a834f52cf26a57f9c419fb83/wrapt-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:fd1f2f557dd3491fe75905e578f4db967393d40d1a8f468edc4d40ac7f2d5944", size = 83921, upload-time = "2026-07-28T06:05:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4c/3d1921a60c3e8c71c540ff136e6a47a1fbccf7f671e818394889f7871d9c/wrapt-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9f5d2aec29dfc76c37e23897dee92766a3fd4f3bff3ae7fc9c6b4bf37d8c1360", size = 84412, upload-time = "2026-07-28T06:05:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/1a/4a796ff7adb26ada6d4b758c94d47a38320b085e7099afc088efbbcdb006/wrapt-2.3.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:646d20d413ffcd1b0a2f700076e2d0252d872dcb7754860a73e45a59ea883614", size = 207168, upload-time = "2026-07-28T06:05:07.256Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3e/d7777776806c579b761bac2f91721dda9f04c7a1b380213c5935cc750ae6/wrapt-2.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:379f670f45b7bb8993edd9f6fc36c6cc65edb81cffa0b504be34acb0303fff0a", size = 214351, upload-time = "2026-07-28T06:05:08.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/2d64d394df7bf181955b3bb562bf33c4492fb4be113f53071106d43ad8b5/wrapt-2.3.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6208f302f110295d64b22a7ac96500c791bf492dce4366e622e4912b077c9687", size = 199020, upload-time = "2026-07-28T06:05:10.418Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3d/fb31d3db7d9834d265fb1a27a2adf0ddf51557c67458c97b22439ad6ae3d/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ed635a9ca4f3a5a2b900c10c69e823373bc00ebc114b459383596d3487da3570", size = 209969, upload-time = "2026-07-28T06:05:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/8724b5da582e62070dc9bf4d8bf1972f317297eefd7ba1f2b5c6393ccf6c/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e3b9eaa742ae7a0aaaaad4ca4b69469d757af2d6e6663ef1dadc47adec0aeb41", size = 196324, upload-time = "2026-07-28T06:05:13.557Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/3d9ef411149543016ee6bcf3af707f787cebd946527452b94bf122e9b7b4/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d0f7284f88f4833705132d06d3b425a43095c2cbd07c58166aac3ab646ba12a4", size = 202610, upload-time = "2026-07-28T06:05:15.048Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9b/4fc042ceb757866dd4a5fc057b3b736f2b360d3703ce9f830d83dc9226e0/wrapt-2.3.0-cp313-cp313t-win32.whl", hash = "sha256:7ebb274aba688b043429eb1500ff8a76ce0cb8ac0812ca3e301f06247b8722b3", size = 79178, upload-time = "2026-07-28T06:05:16.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/b94878f8eed809ca042685276bcea9f24e8c2ca7c9653bb80bbb920a68a5/wrapt-2.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c4bded758ad6f03b965830944a2f0bc5b2eb3767fe5a7310134315d1a6610e98", size = 82634, upload-time = "2026-07-28T06:05:18.026Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/663e1de5332a71685a729754312d327d4cada767c36e1c5a2db4c8de49e6/wrapt-2.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:d2cc64539da63e39ffb9c7ede849b6e8ddaaf7b3876b5cfb04efd85a5f3f4eb6", size = 81387, upload-time = "2026-07-28T06:05:19.417Z" },
+    { url = "https://files.pythonhosted.org/packages/58/10/b073beaea89bc0d3670a75ff51139430a54b6af7ba7796507730634536dd/wrapt-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea52a0d0f08c584943d5764be0e84efa912c8da23c23e1e285ff2f5641c18fcc", size = 81978, upload-time = "2026-07-28T06:05:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/31/0916d9cebf848ed3f1a0c1888faee421747df77331e4db2bc527a9a85988/wrapt-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd85b0aa88efdb189d6ae2f35f4526943a8f091c38599c9c31478241c819e6a1", size = 82518, upload-time = "2026-07-28T06:05:22.562Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/73/31c1bf0f3384062751c2094dadb314916d70aa9b6bfd26d994b4a7b393fa/wrapt-2.3.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:141ed6211286a9660d8d6702de598b43f0934b4f0eda16393f100a80f501d945", size = 170187, upload-time = "2026-07-28T06:05:23.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/25/fce087d54b79b8905f3c3c9dd5f454bbd8d8acb80b960c4a6aee5b4659b3/wrapt-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e49885a62ec4ee854d1b9e6371fda6afd219917225752abf729a3f36d4df9a5", size = 169288, upload-time = "2026-07-28T06:05:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/0d09e6dddc6b7a7230ac77f50254b5980ab4fcd22976f72f8cc8a0404458/wrapt-2.3.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d6159c9b2fefec02314e1332dbbbfaf960e369dfd26bcf7f8b258b5732065b3", size = 160932, upload-time = "2026-07-28T06:05:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ca/0913af0d2ec0c43865d32d615f518fea66c13c5c930e489e9b0de248e9a8/wrapt-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24da48596326ef8e448cfa837b454f638713d3531262375f00e5a9681682fc07", size = 169017, upload-time = "2026-07-28T06:05:28.501Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f2/3d1e47ea81b822210f5df1bf942fd90780a75c055243d569b664529dea88/wrapt-2.3.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cd3a2edf0427013736b8127955cec62608c56e53ea47e82812ea32059cda407f", size = 159065, upload-time = "2026-07-28T06:05:30.01Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a5/ef2066ced8e5fca204e2b361e9708e36555b40949c583d997ea3b590817d/wrapt-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fa0df3bff4e7ce45759f33fd39335fe2f60477bb9ecf7b8aa41e7d07ee36a23", size = 168821, upload-time = "2026-07-28T06:05:31.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e1/016104650d4e572fa91506eb396b3dd8efbccc9284fdc1c9479c3d21db28/wrapt-2.3.0-cp314-cp314-win32.whl", hash = "sha256:2935d5454b3f179a29b12cf390ee47246740ba2c3a7545b1b46ba31a5f2a4a0b", size = 78700, upload-time = "2026-07-28T06:05:33.391Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/6fdc20a9f2ca304748b3f0819cbf377d55260562777bf0b615431bc3c181/wrapt-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:cc2cea812e5cb179a796b766747e7d3b21088760d8deb95676d482b8c8e6fa7d", size = 81422, upload-time = "2026-07-28T06:05:34.774Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a4/9cbd53bf05746bea2c392af39cb052427a8ec95cbd494d930733d8f44681/wrapt-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:22cc5c0a717bd4da87018ae0bffd4c19c6fb679d3ff357216ba566ab26c76cab", size = 80639, upload-time = "2026-07-28T06:05:36.228Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/6c5e4a0f66ea0d2b2dd267e8dd05a0014eea56840b3c8595d40b0a5d1f91/wrapt-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a6b5984cd65dd639546f0eb4b8eacf1c31cb2fe9fb5c27bffe240987cdb2cf84", size = 84030, upload-time = "2026-07-28T06:05:37.714Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/eb/a1aedf03283bc9cbf8a1783995ddc54e3c5a86878f19002d2c428494f4c5/wrapt-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c88abcf53daef80e01a75c7530e727fa6e2c1888fe83e3dcdba4c96216a1f5c7", size = 84419, upload-time = "2026-07-28T06:05:39.131Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/50d511c0dc5105563849e86daa3e16ac7feef699f79fb05af45ea70107d5/wrapt-2.3.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:85de890ff968196e92dd1ae73a9fb8970495e7650a457b1c9ef0ac3dd550bce2", size = 207171, upload-time = "2026-07-28T06:05:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/59/9b538cf7795217e810699d16bc88b96a830d9b5c403eb2ec2db6b5f2ae81/wrapt-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50f416b74d092bb9f41b424e90dd457f365f7ba4b11de62a23679769a21bd85c", size = 214329, upload-time = "2026-07-28T06:05:42.287Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/28/9935d62b1499e5c8b3d191e99ba4eb31ca237a0b699142011a837e9dc7ea/wrapt-2.3.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39febbee6d77301d31da6996b152ce52452da7c7ef72aba10c2fa976dff9c295", size = 199079, upload-time = "2026-07-28T06:05:43.958Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/01/4446b80fa2ffa47a3449b250d004ba1c1937f07f64a179608fec735df866/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:93513bec052c6cd987f9f580c3df068c8bc4ebae6543736be3ca7ec5959cafcd", size = 209992, upload-time = "2026-07-28T06:05:45.677Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/07/56f26c9f9979586a021e8148747004aba4498f49458c90b0502969b904e1/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:729126e667da34d251b8ebf8a45ef0c5ddadc21542b3d6e1abf4259ece6508df", size = 196334, upload-time = "2026-07-28T06:05:47.608Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/41/6d7bcc895b0f28b2250e10908f060687b9165429dcd7f22ddb3d4c031b74/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:626b69db2021aa01671ec7bbc9740e558522bd44c18cf2ce69bf3d666a014109", size = 202644, upload-time = "2026-07-28T06:05:49.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/25/7860927edba06b758b8852a6f02e832be715563c67a6795d94350bc81099/wrapt-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:629d73378082c00a8173031f9fb30a3ac6abbc894a5bfdfae71fabc60642d501", size = 79685, upload-time = "2026-07-28T06:05:50.976Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/0f/270bafe92fde3b069a39bc01e39ee79340895b335640df861d43d2a51885/wrapt-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:42869085687f0aefd57c0f636c3f9354f8ffb321a8ba9cb52d19beb796e561c5", size = 83104, upload-time = "2026-07-28T06:05:52.405Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b3/af176d79a8515a8a720eccdad9a96f6e31a30abf2865430c8c42adf2fd13/wrapt-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b1e5aa486e269b00ed35e64771c7d0ab8096cfd2643405ca8cd60ebedc099a51", size = 81774, upload-time = "2026-07-28T06:05:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/00/39/3daf9f47be208606586de4568ba6713db53ebc8fd7a575aea1fe57983b69/wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2", size = 61866, upload-time = "2026-07-28T06:06:12.9Z" },
 ]


### PR DESCRIPTION
Follows #59.

- **Idempotency**: `POST /orders` accepts an `Idempotency-Key`, reserved inside the order's transaction — so a rejected order leaves the key usable, and a retry returns the original result instead of a second order
- **Consumer lag**: `stream_group_lag` per stream and group. The design note already called lag the metric to alert on; nothing exported it
- **Tracing**: publishers write W3C trace context into the envelope and consumers continue it, so an order and its delivery form one trace. Auto-instrumentation cannot see across the stream hop. Off unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set, and no-ops without the `otel` extra
- **KEDA**: scale orders and delivery on stream lag, not CPU — they are IO-bound. Disabled by default; notifications excluded because it is bound by open SSE streams

Verified with `helm template` that ScaledObjects render against the right Deployments and produce nothing when disabled. Not verified: `docker compose up` end-to-end.