### PR TITLE
Run mongo as a real replica set, cache the menu, read from secondaries

### DIFF
--- a/charts/orders-project/charts/mongodb/values.yaml
+++ b/charts/orders-project/charts/mongodb/values.yaml
@@ -1,4 +1,6 @@
-replicaCount: 1
+# Must stay at 3: init-rs-job initiates rs0 with three members, and a
+# three-member config needs two of them up to elect a primary.
+replicaCount: 3
 
 image:
   repository: mongo

--- a/docs/design.md
+++ b/docs/design.md
@@ -134,8 +134,17 @@ resumes rather than stranding orders.
    RAM. Trimming under a stalled consumer silently drops events, so consumer lag
    is the metric to alert on: every bus reports `stream_group_lag` per stream
    and group, which rises well before trimming starts discarding a backlog.
-2. **MongoDB writes** — a single replica set primary takes every write. Read
-   replicas help reads; write scaling needs sharding.
+2. **MongoDB writes** — a single primary takes every write. `rs0` runs three
+   members, so reads scale out (`GET /orders/{id}` and the menu use
+   `secondaryPreferred`, and the menu is cached in Redis on top), but write
+   scaling would need sharding.
+
+   Sharding is not the next step, and would cost more than it returns. An order
+   writes `menu_items`, `orders` and `outbox` in **one transaction**; sharding
+   splits those across shards and turns every order into a distributed
+   transaction. Keeping it single-shard would need one shard key across all
+   three, which cannot exist — `menu_items` is keyed by item and `orders` by
+   order. The outbox guarantee is what makes "just shard it later" expensive.
 3. **The stateful edge** — SSE streams are long-lived connections, so
    notifications is bound by file descriptors and memory per client long before
    CPU.
@@ -146,8 +155,8 @@ Honest limitations, rather than a feature list:
 
 - **No authentication.** Any client can create an order. Ordering is the demo.
 - **No payments**, which is exactly why no saga is needed yet.
-- **Menu reads hit MongoDB** on every request. An obvious cache, deliberately not
-  built until there is load to justify invalidation.
+- **The stock-refill CronJob writes MongoDB directly** and emits no event, so
+  the menu cache only converges on its 30-second TTL rather than immediately.
 - **Tracing needs a collector.** Spans are produced and propagate across
   streams, but nothing collects them unless `OTEL_EXPORTER_OTLP_ENDPOINT` points
   somewhere. Correlation IDs in Loki remain the default way to follow an order.

--- a/orders/src/cache.py
+++ b/orders/src/cache.py
@@ -1,0 +1,34 @@
+import json
+import logging
+
+from redis.asyncio import Redis
+
+from src.schemas import MenuItemSchema
+
+_KEY = "menu:items"
+# Short enough that the stock-refill CronJob, which writes MongoDB directly and
+# emits no event, cannot leave the menu stale for long.
+_TTL_SECONDS = 30
+
+
+class MenuCache:
+    """Caches the menu list, which is read on every page load and rarely changes."""
+
+    def __init__(self, redis: Redis, ttl_seconds: int = _TTL_SECONDS) -> None:
+        self._redis = redis
+        self._ttl = ttl_seconds
+
+    async def get(self) -> list[MenuItemSchema] | None:
+        cached = await self._redis.get(_KEY)
+        if not cached:
+            return None
+        return [MenuItemSchema.model_validate(item) for item in json.loads(cached)]
+
+    async def set(self, items: list[MenuItemSchema]) -> None:
+        payload = json.dumps([item.model_dump(mode="json") for item in items])
+        await self._redis.set(_KEY, payload, ex=self._ttl)
+
+    async def invalidate(self) -> None:
+        """Drop the cache after stock moves, so the menu never shows sold-out items."""
+        await self._redis.delete(_KEY)
+        logging.debug("Menu cache invalidated")

--- a/orders/src/lifespan.py
+++ b/orders/src/lifespan.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 from fastapi import FastAPI
+from pymongo import ReadPreference
 from shared.db.idempotency import IdempotencyStore
 from shared.db.outbox import MongoOutbox, OutboxRelay
 from shared.logging import setup_logging
@@ -10,6 +11,7 @@ from shared.redis.event_bus import terminate_on_failure
 from shared.redis.publisher import StreamProducer
 from shared.tracing import setup_tracing
 
+from src.cache import MenuCache
 from src.databases import close_databases, connect_databases
 from src.repositories.menu_item_repo import MenuItemRepository
 from src.repositories.order_repository import OrderRepository
@@ -43,6 +45,24 @@ async def startup(app: FastAPI) -> None:
         collection=database.get_collection(settings.mongo_collection_orders),
     )
 
+    # Separate handles for the read paths. A transaction must read from the
+    # primary, so the read preference cannot simply be set on the collections
+    # the write paths already use.
+    menu_read_repo = MenuItemRepository(
+        collection=database.get_collection(
+            settings.mongo_collection_menu_items,
+            read_preference=ReadPreference.SECONDARY_PREFERRED,
+        ),
+    )
+    order_read_repo = OrderRepository(
+        collection=database.get_collection(
+            settings.mongo_collection_orders,
+            read_preference=ReadPreference.SECONDARY_PREFERRED,
+        ),
+    )
+
+    menu_cache = MenuCache(redis_client)
+
     publisher: StreamProducer[Any] = StreamProducer(redis_client, source="orders-service")
 
     outbox = MongoOutbox(collection=database.get_collection(settings.mongo_collection_outbox))
@@ -60,12 +80,19 @@ async def startup(app: FastAPI) -> None:
         redis_client=redis_client,
         menu_repository=menu_repo,
         order_repository=order_repo,
-        menu_service=MenuService(repo=menu_repo, mongo_client=mongo_client),
+        menu_service=MenuService(
+            repo=menu_repo,
+            read_repo=menu_read_repo,
+            cache=menu_cache,
+            mongo_client=mongo_client,
+        ),
         order_service=OrderService(
             order_repo=order_repo,
+            order_read_repo=order_read_repo,
             menu_repo=menu_repo,
             outbox=outbox,
             idempotency=idempotency,
+            menu_cache=menu_cache,
             mongo_client=mongo_client,
         ),
         outbox_relay=relay,

--- a/orders/src/services/menu_service.py
+++ b/orders/src/services/menu_service.py
@@ -1,21 +1,38 @@
 from pymongo import AsyncMongoClient
 
+from src.cache import MenuCache
 from src.repositories.menu_item_repo import MenuItemRepository
 from src.schemas import MenuItemSchema
 from src.services.mixins import TransactionServiceMixin
 
 
 class MenuService(TransactionServiceMixin):
-    def __init__(self, repo: MenuItemRepository, mongo_client: AsyncMongoClient) -> None:
+    def __init__(
+        self,
+        repo: MenuItemRepository,
+        read_repo: MenuItemRepository,
+        cache: MenuCache,
+        mongo_client: AsyncMongoClient,
+    ) -> None:
         super().__init__(mongo_client)
         self._repo = repo
+        # Reads may go to a secondary; writes and transactions must not.
+        self._read_repo = read_repo
+        self._cache = cache
 
     async def get_item(self, item_id: str) -> MenuItemSchema | None:
-        return await self._repo.get_by_id(item_id, session=None)
+        return await self._read_repo.get_by_id(item_id, session=None)
 
     async def list_items(self) -> list[MenuItemSchema]:
-        return await self._repo.find_many({}, session=None)
+        if (cached := await self._cache.get()) is not None:
+            return cached
+
+        items = await self._read_repo.find_many({}, session=None)
+        await self._cache.set(items)
+        return items
 
     async def create_item(self, item: MenuItemSchema) -> str:
         async with self.transaction() as session:
-            return await self._repo.create(item, session=session)
+            item_id = await self._repo.create(item, session=session)
+        await self._cache.invalidate()
+        return item_id

--- a/orders/src/services/order_service.py
+++ b/orders/src/services/order_service.py
@@ -12,6 +12,7 @@ from shared.events.order import (
     OrderStatusSimulated,
 )
 
+from src.cache import MenuCache
 from src.repositories.menu_item_repo import MenuItemRepository
 from src.repositories.order_repository import OrderRepository
 from src.responses import OrderResponse
@@ -41,22 +42,27 @@ class RequestInProgressError(Exception):
 
 
 class OrderService(TransactionServiceMixin):
-    def __init__(
+    def __init__(  # noqa: PLR0913 — collaborators are injected, not configured
         self,
         order_repo: OrderRepository,
+        order_read_repo: OrderRepository,
         menu_repo: MenuItemRepository,
         outbox: MongoOutbox,
         idempotency: IdempotencyStore,
+        menu_cache: MenuCache,
         mongo_client: AsyncMongoClient,
     ) -> None:
         super().__init__(mongo_client)
         self._order_repo = order_repo
+        # Reads may go to a secondary; writes and transactions must not.
+        self._order_read_repo = order_read_repo
         self._menu_repo = menu_repo
         self._outbox = outbox
         self._idempotency = idempotency
+        self._menu_cache = menu_cache
 
     async def get(self, order_id: str) -> OrderSchema | None:
-        return await self._order_repo.get_by_id(order_id, session=None)
+        return await self._order_read_repo.get_by_id(order_id, session=None)
 
     async def create_order_with_stock_check(
         self, order_data: OrderSchema, idempotency_key: str | None = None
@@ -114,6 +120,9 @@ class OrderService(TransactionServiceMixin):
             if idempotency_key and (replay := await self._replay(idempotency_key)):
                 return replay
             raise RequestInProgressError from None
+
+        # Stock just moved, so the cached menu is stale.
+        await self._menu_cache.invalidate()
 
         response = OrderResponse(order=order_data, success=True)
         if idempotency_key:

--- a/orders/tests/test_menu_service.py
+++ b/orders/tests/test_menu_service.py
@@ -23,8 +23,20 @@ def mongo_client():
 
 
 @pytest.fixture
-def service(menu_repo, mongo_client):
-    return MenuService(repo=menu_repo, mongo_client=mongo_client)
+def menu_cache():
+    cache = AsyncMock()
+    cache.get.return_value = None  # cold cache by default
+    return cache
+
+
+@pytest.fixture
+def service(menu_repo, menu_cache, mongo_client):
+    return MenuService(
+        repo=menu_repo,
+        read_repo=menu_repo,
+        cache=menu_cache,
+        mongo_client=mongo_client,
+    )
 
 
 def _make_item(**overrides):
@@ -75,3 +87,41 @@ async def test_create_item(service, menu_repo):
     result = await service.create_item(item)
 
     assert result == "newid"
+
+
+@pytest.mark.asyncio
+async def test_list_items_caches_a_cold_read(service, menu_repo, menu_cache):
+    menu_repo.find_many.return_value = [_make_item()]
+
+    items = await service.list_items()
+
+    assert len(items) == 1
+    menu_cache.set.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_items_serves_the_cache_without_touching_mongo(service, menu_repo, menu_cache):
+    menu_cache.get.return_value = [_make_item(name="Cached")]
+
+    items = await service.list_items()
+
+    assert items[0].name == "Cached"
+    menu_repo.find_many.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_menu_is_still_a_cache_hit(service, menu_repo, menu_cache):
+    """An empty list is a real cached value, not a miss."""
+    menu_cache.get.return_value = []
+
+    assert await service.list_items() == []
+    menu_repo.find_many.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_creating_an_item_invalidates_the_cache(service, menu_repo, menu_cache):
+    menu_repo.create.return_value = "item123"
+
+    await service.create_item(_make_item())
+
+    menu_cache.invalidate.assert_awaited_once()

--- a/orders/tests/test_order_service.py
+++ b/orders/tests/test_order_service.py
@@ -27,6 +27,11 @@ def outbox():
 
 
 @pytest.fixture
+def menu_cache():
+    return AsyncMock()
+
+
+@pytest.fixture
 def idempotency():
     store = AsyncMock()
     store.find.return_value = None
@@ -46,12 +51,14 @@ def mongo_client():
 
 
 @pytest.fixture
-def service(order_repo, menu_repo, outbox, idempotency, mongo_client):
+def service(order_repo, menu_repo, outbox, idempotency, menu_cache, mongo_client):
     return OrderService(
         order_repo=order_repo,
+        order_read_repo=order_repo,
         menu_repo=menu_repo,
         outbox=outbox,
         idempotency=idempotency,
+        menu_cache=menu_cache,
         mongo_client=mongo_client,
     )
 
@@ -185,6 +192,29 @@ async def test_status_event_carries_the_orders_own_simulation_flag(service, orde
     await service.handle_status_update(OrderStatusSimulated(id="order123", status="out_for_delivery"))
 
     assert outbox.add.call_args.args[0].simulation == -1
+
+
+@pytest.mark.asyncio
+async def test_placing_an_order_invalidates_the_menu_cache(service, menu_repo, order_repo, menu_cache):
+    """Stock just moved, so a cached menu would advertise items that are gone."""
+    menu_repo.get_by_id.return_value = MenuItemSchema(
+        name="Burger", price=9.99, category="food", stock=10, id="507f1f77bcf86cd799439011"
+    )
+    menu_repo.decrement_stock.return_value = True
+    order_repo.create.return_value = "order123"
+
+    await service.create_order_with_stock_check(_make_order())
+
+    menu_cache.invalidate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rejected_order_leaves_the_cache_alone(service, menu_repo, menu_cache):
+    menu_repo.get_by_id.return_value = None
+
+    await service.create_order_with_stock_check(_make_order())
+
+    menu_cache.invalidate.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/orders/tests/test_outbox_integration.py
+++ b/orders/tests/test_outbox_integration.py
@@ -56,11 +56,14 @@ async def idempotency(database):
 
 @pytest.fixture
 async def service(database, outbox, idempotency):
+    order_repo = OrderRepository(collection=database["orders"])
     return OrderService(
-        order_repo=OrderRepository(collection=database["orders"]),
+        order_repo=order_repo,
+        order_read_repo=order_repo,
         menu_repo=MenuItemRepository(collection=database["menu_items"]),
         outbox=outbox,
         idempotency=idempotency,
+        menu_cache=AsyncMock(),
         mongo_client=database.client,
     )
 


### PR DESCRIPTION
Storage plan items 1-3.

- **Replica set**: `replicaCount` was 1 while `init-rs-job` initiates `rs0` with three members. Three configured members need two up to elect a primary, so the chart was internally inconsistent.
- **Menu cache**: Redis, 30s TTL, invalidated when stock moves.
- **Secondary reads**: `GET /orders/{id}` and menu reads, via separate collection handles since transactions must read the primary.

Sharding deliberately not done — an order writes `menu_items`, `orders` and `outbox` in one transaction, and sharding turns that into a distributed transaction. Reasoning recorded in the design note.