### PR TITLE
Publish images to GHCR only

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
-    environment: docker hub
     permissions:
       contents: read
       packages: write
@@ -45,12 +44,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -62,12 +55,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            kkaarroollm/${{ matrix.name }}
-            ghcr.io/kkaarroollm/${{ matrix.name }}
+          images: ghcr.io/kkaarroollm/${{ matrix.name }}
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
 
       - name: Build and push ${{ matrix.name }}
         uses: docker/build-push-action@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orders-project-workspace"
-version = "0.2.0"
+version = "0.2.1"
 description = "Workspace root for all Python services"
 requires-python = ">=3.13"
 dependencies = []


### PR DESCRIPTION
Docker Hub login rejected the credentials on every attempt and it runs
before the GHCR login, so nothing reached either registry. GHCR
authenticates with the built-in GITHUB_TOKEN and needs no secrets.

Also stop tagging prereleases as latest.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
