### PR TITLE
Redesign the frontend and route the prod frontend through nginx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ shared/build/
 shared/src/*.egg-info/
 
 docs/_build/
+
+# Local design reference, not part of the repo
+frontend/DESIGN.md

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from '@tanstack/react-router';
 import { router } from '@/router';
 import { ThemeProvider } from '@/components/theme-provider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CartProvider } from '@/store/cart';
 
 const queryClient = new QueryClient();
 
@@ -9,7 +10,10 @@ function App() {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="ui-theme">
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        {/* Above the router so the header badge and every page share one cart. */}
+        <CartProvider>
+          <RouterProvider router={router} />
+        </CartProvider>
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,26 +1,146 @@
 import { ReactNode } from 'react';
-import { Link } from '@tanstack/react-router';
-import { ShoppingCart, Wrench } from 'lucide-react';
+import { Link, useRouterState } from '@tanstack/react-router';
+import { ShoppingBag, Wrench } from 'lucide-react';
 import { ModeToggle } from './mode-toggle';
+import { useCart } from '@/hooks/useCart';
+import { cn } from '@/lib/utils';
+
+const BrandMark = () => (
+  <svg
+    width="26"
+    height="26"
+    viewBox="0 0 26 26"
+    role="img"
+    aria-label="Orders"
+    className="shrink-0"
+  >
+    <circle cx="13" cy="13" r="12" fill="var(--primary)" />
+    <path
+      d="M7 16.5 L7 11 L13 7.5 L19 11 L19 16.5"
+      fill="none"
+      stroke="var(--primary-foreground)"
+      strokeWidth="1.6"
+      strokeLinejoin="round"
+      strokeLinecap="round"
+    />
+    <circle cx="13" cy="14" r="2.2" fill="var(--primary-foreground)" />
+  </svg>
+);
+
+const NavLink = ({
+  to,
+  active,
+  children,
+}: {
+  to: string;
+  active: boolean;
+  children: ReactNode;
+}) => (
+  <Link
+    to={to}
+    className={cn(
+      'rounded-full px-3 py-1.5 text-sm transition-colors',
+      active
+        ? 'font-semibold text-brand'
+        : 'text-foreground/80 hover:text-brand',
+    )}
+  >
+    {children}
+  </Link>
+);
+
+/**
+ * The floating circular order button. DESIGN.md treats this as the product's
+ * signature elevation element: it persists over every shopping surface and
+ * loses its ambient shadow on press.
+ */
+const FloatingCartButton = ({ count }: { count: number }) => (
+  <Link
+    to="/cart"
+    aria-label={`Review cart, ${count} item${count === 1 ? '' : 's'}`}
+    className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-float transition-all duration-200 active:scale-95 active:shadow-[var(--shadow-float-active)]"
+  >
+    <ShoppingBag className="h-5 w-5" />
+    <span className="numeric absolute -right-0.5 -top-0.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground px-1 text-[0.7rem] font-semibold text-background">
+      {count}
+    </span>
+  </Link>
+);
 
 const Layout = ({ children }: { children?: ReactNode }) => {
+  const { itemCount } = useCart();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const onShoppingSurface = pathname !== '/cart' && pathname !== '/order';
+
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-      <header className="p-4 border-b bg-gray-100 dark:bg-gray-800 flex justify-between items-center">
-        <h1 className="text-xl font-bold">
-          <Link to="/">🛒 Order what you want</Link>
-        </h1>
-        <div className="flex items-center gap-4">
-          <ModeToggle />
-          <Link to="/dev">
-            <Wrench className="h-5 w-5 hover:text-blue-500 transition" />
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <header className="sticky top-0 z-40 bg-card shadow-nav">
+        <div className="mx-auto flex h-16 w-full max-w-6xl items-center gap-4 px-4 sm:h-[72px] sm:px-6">
+          <Link to="/" className="flex items-center gap-2.5">
+            <BrandMark />
+            <span className="text-base font-semibold text-brand">Orders</span>
           </Link>
-          <Link to="/cart">
-            <ShoppingCart className="h-6 w-6 hover:text-blue-500 transition" />
-          </Link>
+
+          <nav className="ml-3 hidden items-center gap-1 sm:flex">
+            <NavLink to="/" active={pathname === '/'}>
+              Menu
+            </NavLink>
+            <NavLink to="/cart" active={pathname === '/cart'}>
+              Cart
+            </NavLink>
+          </nav>
+
+          <div className="ml-auto flex items-center gap-2">
+            <ModeToggle />
+
+            <Link
+              to="/dev"
+              aria-label="Dev tools"
+              className={cn(
+                'rounded-full p-2 transition-colors',
+                pathname === '/dev'
+                  ? 'text-brand'
+                  : 'text-muted-foreground hover:text-brand',
+              )}
+            >
+              <Wrench className="h-4 w-4" />
+            </Link>
+
+            <Link
+              to="/cart"
+              aria-label={`Cart, ${itemCount} item${itemCount === 1 ? '' : 's'}`}
+              className="relative rounded-full border border-foreground/80 px-4 py-[7px] text-sm font-semibold transition-all duration-200 active:scale-95"
+            >
+              Cart
+              {itemCount > 0 && (
+                <span className="numeric ml-1.5">({itemCount})</span>
+              )}
+            </Link>
+          </div>
         </div>
       </header>
-      <main className="p-4">{children}</main>
+
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6 sm:py-14">
+        {children}
+      </main>
+
+      {itemCount > 0 && onShoppingSurface && (
+        <FloatingCartButton count={itemCount} />
+      )}
+
+      {/* Deep-tier bookend, the way the system closes every page */}
+      <footer className="bg-deep text-white">
+        <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-end gap-3 px-4 py-8 sm:px-6">
+          <a
+            href="https://github.com/kkaarroollm/orders-project"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-semibold text-white underline-offset-4 hover:underline"
+          >
+            Source
+          </a>
+        </div>
+      </footer>
     </div>
   );
 };

--- a/frontend/src/components/OrderTracker.tsx
+++ b/frontend/src/components/OrderTracker.tsx
@@ -1,9 +1,16 @@
-import React, { JSX } from 'react';
-import { useOrderTracking } from '@/hooks/useOrderTracking';
-import { Card } from '@/components/ui/card';
 import { motion } from 'framer-motion';
-import { CheckCircle, Truck, Timer, Package } from 'lucide-react';
+import {
+  Check,
+  ChefHat,
+  PackageCheck,
+  Truck,
+  Bike,
+  Warehouse,
+  type LucideIcon,
+} from 'lucide-react';
+import { useOrderTracking } from '@/hooks/useOrderTracking';
 import { OrderStatus } from '@/types';
+import { cn } from '@/lib/utils';
 
 const statuses: OrderStatus[] = [
   OrderStatus.CONFIRMED,
@@ -14,120 +21,173 @@ const statuses: OrderStatus[] = [
   OrderStatus.DELIVERED,
 ];
 
-const statusIcons: Record<OrderStatus, JSX.Element> = {
-  [OrderStatus.CONFIRMED]: <CheckCircle className="h-6 w-6" />,
-  [OrderStatus.PREPARING]: <Timer className="h-6 w-6" />,
-  [OrderStatus.OUT_FOR_DELIVERY]: <Truck className="h-6 w-6" />,
-  [OrderStatus.WAITING_FOR_PICKUP]: <Timer className="h-6 w-6" />,
-  [OrderStatus.ON_THE_WAY]: <Truck className="h-6 w-6" />,
-  [OrderStatus.DELIVERED]: <Package className="h-6 w-6" />,
+const statusIcons: Record<OrderStatus, LucideIcon> = {
+  [OrderStatus.CONFIRMED]: Check,
+  [OrderStatus.PREPARING]: ChefHat,
+  [OrderStatus.OUT_FOR_DELIVERY]: Warehouse,
+  [OrderStatus.WAITING_FOR_PICKUP]: Truck,
+  [OrderStatus.ON_THE_WAY]: Bike,
+  [OrderStatus.DELIVERED]: PackageCheck,
 };
 
 const timelineLabels: Record<OrderStatus, string> = {
   [OrderStatus.CONFIRMED]: 'Confirmed',
   [OrderStatus.PREPARING]: 'Preparing',
-  [OrderStatus.OUT_FOR_DELIVERY]: 'Out for Delivery',
+  [OrderStatus.OUT_FOR_DELIVERY]: 'Out for delivery',
   [OrderStatus.WAITING_FOR_PICKUP]: 'Pickup',
-  [OrderStatus.ON_THE_WAY]: 'On The Way',
+  [OrderStatus.ON_THE_WAY]: 'On the way',
   [OrderStatus.DELIVERED]: 'Delivered',
 };
 
 const statusMessages: Record<OrderStatus, string> = {
-  [OrderStatus.CONFIRMED]:
-    'Your order has been confirmed and is now being processed.',
-  [OrderStatus.PREPARING]:
-    'We are preparing your order. It will be ready for shipment shortly.',
-  [OrderStatus.OUT_FOR_DELIVERY]:
-    'Your order is out for delivery. Get ready to receive it!',
-  [OrderStatus.WAITING_FOR_PICKUP]:
-    'Your order is waiting for pickup. The courier will collect it soon.',
-  [OrderStatus.ON_THE_WAY]: 'Your order is on the way to your location.',
-  [OrderStatus.DELIVERED]:
-    'Your order has been delivered. Enjoy your purchase!',
+  [OrderStatus.CONFIRMED]: 'The order is confirmed and queued for the kitchen.',
+  [OrderStatus.PREPARING]: 'It is being prepared. Shipment follows shortly.',
+  [OrderStatus.OUT_FOR_DELIVERY]: 'It has left the kitchen for the depot.',
+  [OrderStatus.WAITING_FOR_PICKUP]: 'Waiting for a courier to collect it.',
+  [OrderStatus.ON_THE_WAY]: 'A courier is on the way to your address.',
+  [OrderStatus.DELIVERED]: 'Delivered. Enjoy it.',
 };
 
-const statusVariants = {
-  hidden: { opacity: 0, scale: 0.9 },
-  visible: { opacity: 1, scale: 1, transition: { duration: 0.5 } },
-};
+const ConnectionPill = ({ connected }: { connected: boolean }) => (
+  <span className="flex items-center gap-1.5">
+    <span className="relative flex h-1.5 w-1.5">
+      {connected && (
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-success opacity-70" />
+      )}
+      <span
+        className={cn(
+          'relative inline-flex h-1.5 w-1.5 rounded-full',
+          connected ? 'bg-success' : 'bg-muted-foreground',
+        )}
+      />
+    </span>
+    <span className="label">{connected ? 'SSE live' : 'Reconnecting'}</span>
+  </span>
+);
+
+const clockTime = (ms: number) =>
+  new Date(ms).toLocaleTimeString('en-GB', { hour12: false });
 
 export default function OrderTracker({ orderId }: { orderId: string }) {
-  const { status: currentStatus, isConnected } = useOrderTracking(orderId);
+  const {
+    status: currentStatus,
+    events,
+    isConnected,
+  } = useOrderTracking(orderId);
 
-  if (!currentStatus) {
-    return (
-      <Card className="p-6 space-y-4 dark:bg-gray-800">
-        <h1 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100">
-          📦 Order Tracking
-        </h1>
-        <p className="text-gray-500 text-center">
-          {isConnected ? 'Loading order status...' : 'Connecting...'}
-        </p>
-      </Card>
-    );
-  }
-
-  const currentIndex = statuses.indexOf(currentStatus);
+  const currentIndex = currentStatus ? statuses.indexOf(currentStatus) : -1;
+  const progress =
+    currentIndex < 0 ? 0 : (currentIndex / (statuses.length - 1)) * 100;
+  const CurrentIcon = currentStatus ? statusIcons[currentStatus] : null;
 
   return (
-    <Card className="p-6 space-y-8 dark:bg-gray-800">
-      <h1 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100">
-        📦 Order Tracking
-      </h1>
-
-      <div className="flex items-center justify-center space-x-6">
-        {statuses.map((status, index) => {
-          const isActive = index <= currentIndex;
-          return (
-            <div key={status} className="flex flex-col items-center">
-              <div
-                className={`rounded-full p-2 
-                  ${
-                    isActive
-                      ? 'bg-blue-500 dark:bg-blue-600'
-                      : 'bg-gray-300 dark:bg-gray-700'
-                  }
-                `}
-              >
-                {React.cloneElement(statusIcons[status], {
-                  className: isActive
-                    ? 'h-6 w-6 text-white'
-                    : 'h-6 w-6 text-gray-600 dark:text-gray-300',
-                })}
-              </div>
-
-              <span
-                className={`mt-1 text-xs 
-                  ${
-                    isActive
-                      ? 'text-blue-500 dark:text-blue-400 font-semibold'
-                      : 'text-gray-500 dark:text-gray-400'
-                  }
-                `}
-              >
-                {timelineLabels[status]}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-
-      <motion.div
-        key={currentStatus}
-        initial="hidden"
-        animate="visible"
-        variants={statusVariants}
-        className="flex flex-col items-center space-y-3"
-      >
-        <div className="rounded-full p-4 bg-blue-500 dark:bg-blue-600">
-          {React.cloneElement(statusIcons[currentStatus], {
-            className: 'h-10 w-10 text-white',
-          })}
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-col gap-2">
+          <p className="label">Tracking</p>
+          <h1 className="text-[2.8rem] font-semibold leading-[1.2] text-brand">
+            {currentStatus
+              ? timelineLabels[currentStatus]
+              : 'Waiting for the first event'}
+          </h1>
+          <p className="numeric text-sm text-muted-foreground">{orderId}</p>
         </div>
-        <p className="text-base text-center text-gray-700 dark:text-gray-200">
-          {statusMessages[currentStatus]}
-        </p>
-      </motion.div>
-    </Card>
+        <ConnectionPill connected={isConnected} />
+      </header>
+
+      <section className="surface-card p-6 sm:p-7">
+        {/* progress rail */}
+        <div className="relative mb-6 h-0.5 w-full bg-border">
+          <motion.div
+            className="absolute inset-y-0 left-0 bg-primary"
+            initial={{ width: 0 }}
+            animate={{ width: `${progress}%` }}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
+          />
+        </div>
+
+        <ol className="grid grid-cols-3 gap-y-6 sm:grid-cols-6">
+          {statuses.map((status, index) => {
+            const Icon = statusIcons[status];
+            const reached = index <= currentIndex;
+            const isCurrent = index === currentIndex;
+
+            return (
+              <li
+                key={status}
+                className="flex flex-col items-center gap-2 text-center"
+              >
+                <span
+                  className={cn(
+                    'flex h-9 w-9 items-center justify-center rounded-full border transition-colors',
+                    reached
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-border bg-muted text-muted-foreground',
+                    isCurrent &&
+                      'ring-2 ring-primary/30 ring-offset-2 ring-offset-card',
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                </span>
+                <span
+                  className={cn(
+                    'text-xs leading-tight',
+                    reached ? 'text-foreground' : 'text-muted-foreground',
+                  )}
+                >
+                  {timelineLabels[status]}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+
+      {currentStatus && CurrentIcon ? (
+        <motion.section
+          key={currentStatus}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.35, ease: 'easeOut' }}
+          className="surface-card flex items-center gap-4 p-6"
+        >
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-accent text-accent-foreground">
+            <CurrentIcon className="h-5 w-5" />
+          </span>
+          <p className="text-sm">{statusMessages[currentStatus]}</p>
+        </motion.section>
+      ) : (
+        <section className="surface-card p-10 text-center">
+          <p className="text-sm text-muted-foreground">
+            {isConnected
+              ? 'Connected. Waiting for the first status to be pushed.'
+              : 'Opening the event stream…'}
+          </p>
+        </section>
+      )}
+
+      {events.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h2 className="label">Events received</h2>
+          <ul className="surface-card overflow-hidden font-mono text-xs">
+            {events.map((event) => (
+              <li
+                key={`${event.status}-${event.receivedAt}`}
+                className="flex items-center gap-4 border-b border-border px-4 py-2.5 last:border-b-0"
+              >
+                <span className="numeric text-muted-foreground">
+                  {clockTime(event.receivedAt)}
+                </span>
+                <span>{event.status}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-muted-foreground">
+            Each line arrived as a server-sent push from the notifications
+            service, not from polling.
+          </p>
+        </section>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,27 +4,28 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
+// Every button is a full pill with a scale(0.95) press — DESIGN.md treats
+// both as universal, no exceptions.
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-semibold transition-all duration-200 active:scale-95 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+          'border border-primary bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'border border-destructive bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          'border border-primary bg-transparent text-primary hover:bg-primary/5',
         secondary:
-          'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
-        ghost:
-          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+          'border border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        default: 'h-9 px-4 py-[7px] has-[>svg]:px-3',
+        sm: 'h-8 gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-11 px-6 text-base has-[>svg]:px-4',
         icon: 'size-9',
       },
     },

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-lg py-6 shadow-card',
         className,
       )}
       {...props}

--- a/frontend/src/hooks/useCart.ts
+++ b/frontend/src/hooks/useCart.ts
@@ -1,44 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useContext } from 'react';
+import { CartContext, type CartContextValue } from '@/store/cart-context';
 
-type Cart = { [itemId: string]: { quantity: number; price: number } };
-
-export const useCart = () => {
-  const [cart, setCart] = useState<Cart>(() => {
-    const savedCart = localStorage.getItem('cart');
-    return savedCart ? JSON.parse(savedCart) : {};
-  });
-
-  useEffect(() => {
-    localStorage.setItem('cart', JSON.stringify(cart));
-  }, [cart]);
-
-  const updateCart = (
-    itemId: string,
-    quantity: number,
-    stock: number,
-    price: number,
-  ) => {
-    if (!itemId) return;
-
-    const safeQuantity = Math.min(quantity, stock);
-
-    setCart((prevCart) => {
-      const newCart = { ...prevCart };
-
-      if (safeQuantity > 0) {
-        newCart[itemId] = { quantity: safeQuantity, price };
-      } else {
-        delete newCart[itemId];
-      }
-
-      return newCart;
-    });
-  };
-
-  const clearCart = () => {
-    setCart({});
-    localStorage.removeItem('cart');
-  };
-
-  return { cart, updateCart, clearCart };
+export const useCart = (): CartContextValue => {
+  const ctx = useContext(CartContext);
+  if (!ctx) {
+    throw new Error('useCart must be used inside a CartProvider');
+  }
+  return ctx;
 };
+
+export type { Cart, CartLine } from '@/store/cart-context';

--- a/frontend/src/hooks/useOrderTracking.ts
+++ b/frontend/src/hooks/useOrderTracking.ts
@@ -2,12 +2,21 @@ import { useEffect, useState } from 'react';
 import { OrderStatus } from '@/types.ts';
 import { NOTIFICATION_SSE_URL } from '@/config/env';
 
+export interface TrackingEvent {
+  status: OrderStatus;
+  receivedAt: number;
+}
+
 export function useOrderTracking(orderId: string) {
   const [status, setStatus] = useState<OrderStatus | null>(null);
+  const [events, setEvents] = useState<TrackingEvent[]>([]);
   const [isConnected, setIsConnected] = useState(false);
 
   useEffect(() => {
     if (!orderId) return;
+
+    setStatus(null);
+    setEvents([]);
 
     const source = new EventSource(
       `${NOTIFICATION_SSE_URL}/api/v1/order-tracking/${orderId}`,
@@ -16,7 +25,15 @@ export function useOrderTracking(orderId: string) {
     source.onopen = () => setIsConnected(true);
     source.onmessage = (event: MessageEvent) => {
       const data = JSON.parse(event.data);
-      setStatus(data.status as OrderStatus);
+      const next = data.status as OrderStatus;
+      setStatus(next);
+      // Kept so the page can show that each status arrived as its own push,
+      // rather than as the result of polling.
+      setEvents((prev) =>
+        prev.length > 0 && prev[prev.length - 1].status === next
+          ? prev
+          : [...prev, { status: next, receivedAt: Date.now() }],
+      );
     };
     // EventSource reconnects on its own, using the server's `retry` interval.
     source.onerror = () => setIsConnected(false);
@@ -24,5 +41,5 @@ export function useOrderTracking(orderId: string) {
     return () => source.close();
   }, [orderId]);
 
-  return { status, isConnected };
+  return { status, events, isConnected };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,80 +3,108 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * Structure follows DESIGN.md — warm canvas, pill buttons, 12px cards,
+ * layered whisper shadows, tight tracking. The palette is this project's
+ * override: a four-tier red system replacing the four greens, each tier
+ * keeping the surface role the original assigned to it.
+ *
+ * Brand red is warm brick; error red is deliberately cooler and more
+ * saturated so a failure never reads as brand chrome, and it is always paired
+ * with an icon and a tint rather than relying on hue alone.
+ */
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --radius: 0.75rem; /* 12px card radius */
+
+  /* canvas & surfaces */
+  --background: #f3f1ed; /* warm neutral canvas, never pure white */
+  --foreground: rgba(0, 0, 0, 0.87); /* never pure black */
+  --card: #ffffff;
+  --card-foreground: rgba(0, 0, 0, 0.87);
+  --popover: #faf9f7;
+  --popover-foreground: rgba(0, 0, 0, 0.87);
+
+  /* four-tier red system, each with its own role */
+  --brand: #8a1e1e; /* headings */
+  --primary: #af2318; /* filled CTAs, floating button */
+  --primary-foreground: #ffffff;
+  --deep: #3a1210; /* bands, footer, dark canvas */
+  --uplift: #6e2a22; /* decorative */
+  --brand-light: #f7deda; /* light washes and tints */
+
+  --secondary: #ebe7e2;
+  --secondary-foreground: rgba(0, 0, 0, 0.87);
+  --muted: #f8f7f5;
+  --muted-foreground: rgba(0, 0, 0, 0.58);
+  --accent: #f7deda;
+  --accent-foreground: #8a1e1e;
+
+  /* semantic — green is now free to mean only "success" */
+  --destructive: #c21a3f;
+  --warning: #d9822b;
+  --success: #2e7d52;
+
+  --border: rgba(0, 0, 0, 0.12);
+  --input: rgba(0, 0, 0, 0.24);
+  --ring: #af2318;
+
+  /* layered whisper-soft elevation, never a single heavy shadow */
+  --shadow-card:
+    0 0 0.5px 0 rgba(0, 0, 0, 0.14), 0 1px 1px 0 rgba(0, 0, 0, 0.24);
+  --shadow-nav:
+    0 1px 3px rgba(0, 0, 0, 0.1), 0 2px 2px rgba(0, 0, 0, 0.06),
+    0 0 2px rgba(0, 0, 0, 0.07);
+  --shadow-float: 0 0 6px rgba(0, 0, 0, 0.24), 0 8px 12px rgba(0, 0, 0, 0.14);
+  --shadow-float-active: 0 0 6px rgba(0, 0, 0, 0.24), 0 8px 12px rgba(0, 0, 0, 0);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: #2a100e; /* the deep tier carries the whole page */
+  --foreground: #ffffff;
+  --card: #3a1815;
+  --card-foreground: #ffffff;
+  --popover: #3a1815;
+  --popover-foreground: #ffffff;
+
+  --brand: #ffffff;
+  /* Inverted CTA rule: on a deep brand surface the button is white with
+     brand-coloured text, not a red pill on red. */
+  --primary: #ffffff;
+  --primary-foreground: #af2318;
+  --deep: #1e0a09;
+  --uplift: #6e2a22;
+  --brand-light: #f7deda;
+
+  --secondary: #4a211c;
+  --secondary-foreground: #ffffff;
+  --muted: #4a211c;
+  --muted-foreground: rgba(255, 255, 255, 0.7);
+  --accent: #4a211c;
+  --accent-foreground: #ffffff;
+
+  --destructive: #ffb4a9;
+  --warning: #f5b461;
+  --success: #7fd1a3;
+
+  --border: rgba(255, 255, 255, 0.16);
+  --input: rgba(255, 255, 255, 0.32);
+  --ring: #ffffff;
+
+  --shadow-card:
+    0 0 0.5px 0 rgba(0, 0, 0, 0.3), 0 1px 1px 0 rgba(0, 0, 0, 0.4);
+  --shadow-nav:
+    0 1px 3px rgba(0, 0, 0, 0.3), 0 2px 2px rgba(0, 0, 0, 0.2),
+    0 0 2px rgba(0, 0, 0, 0.2);
+  --shadow-float: 0 0 6px rgba(0, 0, 0, 0.4), 0 8px 12px rgba(0, 0, 0, 0.3);
+  --shadow-float-active: 0 0 6px rgba(0, 0, 0, 0.4), 0 8px 12px rgba(0, 0, 0, 0);
 }
 
 @theme inline {
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 6px);
+  --radius-md: calc(var(--radius) - 3px);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-xl: var(--radius);
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -92,29 +120,66 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
+  --color-success: var(--success);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
+
+  --color-brand: var(--brand);
+  --color-deep: var(--deep);
+  --color-uplift: var(--uplift);
+  --color-brand-light: var(--brand-light);
+
+  --shadow-card: var(--shadow-card);
+  --shadow-nav: var(--shadow-nav);
+  --shadow-float: var(--shadow-float);
+
+  --font-sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
+    'Liberation Mono', monospace;
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans antialiased;
+    /* tight tracking is load-bearing across the whole system */
+    letter-spacing: -0.01em;
+  }
+
+  h1,
+  h2,
+  h3 {
+    letter-spacing: -0.01em;
+  }
+
+  .label {
+    @apply text-[0.75rem] font-semibold uppercase text-muted-foreground;
+    letter-spacing: 0.15em;
+  }
+
+  .numeric {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .surface-card {
+    background-color: var(--card);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-card);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -1,51 +1,134 @@
-import { useCart } from '../hooks/useCart.ts';
-import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
 import { Link } from '@tanstack/react-router';
+import { Minus, Plus, Trash2, ShoppingBag } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useCart } from '@/hooks/useCart';
+
+const currency = (value: number) =>
+  value.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
 
 const CartPage = () => {
-  const { cart } = useCart();
+  const { lines, totalPrice, itemCount, setQuantity, clearCart } = useCart();
 
-  const validCart = Object.entries(cart).filter(
-    ([, item]) => item.quantity > 0,
-  );
+  if (lines.length === 0) {
+    return (
+      <div className="flex flex-col gap-8">
+        <h1 className="text-[2.8rem] font-semibold leading-[1.2] text-brand">
+          Nothing here yet
+        </h1>
 
-  const totalPrice = validCart.reduce(
-    (acc, [, item]) => acc + item.quantity * item.price,
-    0,
-  );
+        <div className="surface-card flex flex-col items-center gap-5 px-6 py-16">
+          <ShoppingBag className="h-7 w-7 text-primary" />
+          <p className="text-muted-foreground">Your cart is empty.</p>
+          <Link to="/">
+            <Button variant="outline">Browse the menu</Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">🛍 Your Cart</h1>
+    <div className="flex flex-col gap-8">
+      <h1 className="text-[2.8rem] font-semibold leading-[1.2] text-brand">
+        {itemCount} item{itemCount === 1 ? '' : 's'} ready to order
+      </h1>
 
-      {validCart.length > 0 ? (
-        <Card className="p-4 mt-4">
-          {validCart.map(([itemId, item]) => (
-            <p key={itemId}>
-              Item {itemId}: {item.quantity} pcs - ${item.price.toFixed(2)} each
-            </p>
+      <div className="grid gap-6 lg:grid-cols-[1fr_340px] lg:items-start">
+        <ul className="flex flex-col gap-4">
+          {lines.map((line) => (
+            <li
+              key={line.itemId}
+              className="surface-card flex items-center gap-4 p-5"
+            >
+              <div className="min-w-0 flex-1">
+                <h2 className="font-semibold">{line.name || 'Unnamed item'}</h2>
+                <p className="numeric mt-0.5 text-sm text-muted-foreground">
+                  {currency(line.price)} each
+                </p>
+              </div>
+
+              <div className="flex items-center gap-1 rounded-full border border-primary p-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-primary"
+                  aria-label={`Remove one ${line.name}`}
+                  onClick={() =>
+                    setQuantity(line.itemId, line.quantity - 1, line)
+                  }
+                >
+                  <Minus className="h-3.5 w-3.5" />
+                </Button>
+                <span className="numeric w-7 text-center text-sm font-semibold">
+                  {line.quantity}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-primary"
+                  aria-label={`Add one ${line.name}`}
+                  disabled={line.quantity >= line.stock}
+                  onClick={() =>
+                    setQuantity(line.itemId, line.quantity + 1, line)
+                  }
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+
+              <span className="numeric w-20 shrink-0 text-right font-semibold">
+                {currency(line.price * line.quantity)}
+              </span>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                aria-label={`Remove ${line.name} from cart`}
+                onClick={() => setQuantity(line.itemId, 0, line)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </li>
           ))}
-          <Separator className="my-2" />
-          <h3 className="text-lg font-bold">Total: ${totalPrice.toFixed(2)}</h3>
-        </Card>
-      ) : (
-        <p className="text-gray-500 mt-4">No items in cart.</p>
-      )}
+        </ul>
 
-      <div className="mt-4">
-        {validCart.length > 0 ? (
-          <Link to="/order">
-            <Button variant="default" size="lg" className="w-full">
-              Proceed to Checkout
+        <aside className="surface-card flex flex-col gap-5 p-6 lg:sticky lg:top-24">
+          <h2 className="label">Summary</h2>
+
+          <dl className="flex flex-col gap-2.5 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Items</dt>
+              <dd className="numeric">{itemCount}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Delivery</dt>
+              <dd>Free</dd>
+            </div>
+          </dl>
+
+          <div className="flex items-baseline justify-between border-t border-border pt-5">
+            <span className="font-semibold">Total</span>
+            <span className="numeric text-xl font-semibold">
+              {currency(totalPrice)}
+            </span>
+          </div>
+
+          <Link to="/order" className="w-full">
+            <Button size="lg" className="w-full">
+              Checkout
             </Button>
           </Link>
-        ) : (
-          <Button variant="default" size="lg" className="w-full" disabled>
-            ❌ Cart is Empty
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearCart}
+            className="text-muted-foreground"
+          >
+            Clear cart
           </Button>
-        )}
+        </aside>
       </div>
     </div>
   );

--- a/frontend/src/pages/DevTools.tsx
+++ b/frontend/src/pages/DevTools.tsx
@@ -1,101 +1,128 @@
 import { ExternalLink } from 'lucide-react';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from '@/components/ui/card';
 
-const tools = [
+interface Tool {
+  title: string;
+  description: string;
+  url: string;
+  badge?: string;
+  credentials?: string;
+}
+
+const groups: Array<{ heading: string; blurb: string; tools: Tool[] }> = [
   {
-    title: 'Grafana — HTTP Metrics',
-    description: 'Request rate, latency percentiles & error rates',
-    url: '/grafana/d/http-metrics/http-metrics',
-    badge: 'read-only',
+    heading: 'Dashboards',
+    blurb:
+      'Prometheus scrapes RED metrics and per-stream consumer lag; Loki holds the logs, keyed by correlation id.',
+    tools: [
+      {
+        title: 'HTTP metrics',
+        description: 'Request rate, latency percentiles and error rates',
+        url: '/grafana/d/http-metrics/http-metrics',
+        badge: 'read-only',
+      },
+      {
+        title: 'Application logs',
+        description: 'Live log stream, volume and error tracking (Loki)',
+        url: '/grafana/d/application-logs/application-logs',
+        badge: 'read-only',
+      },
+      {
+        title: 'Event pipeline',
+        description: 'Stream throughput, processing latency and dead letters',
+        url: '/grafana/d/event-pipeline/event-pipeline',
+        badge: 'read-only',
+      },
+      {
+        title: 'Grafana',
+        description: 'All dashboards, explore and admin',
+        url: '/grafana/',
+        credentials: 'admin / admin',
+      },
+      {
+        title: 'Prometheus',
+        description: 'Metrics collection, PromQL queries and targets',
+        url: '/prometheus/',
+        badge: 'read-only',
+      },
+    ],
   },
   {
-    title: 'Grafana — Application Logs',
-    description: 'Live log stream, volume & error tracking (Loki)',
-    url: '/grafana/d/application-logs/application-logs',
-    badge: 'read-only',
-  },
-  {
-    title: 'Grafana — Event Pipeline',
-    description: 'Stream throughput, processing latency & dead-letter queue',
-    url: '/grafana/d/event-pipeline/event-pipeline',
-    badge: 'read-only',
-  },
-  {
-    title: 'Grafana',
-    description: 'All dashboards, explore & admin',
-    url: '/grafana/',
-    credentials: 'admin / admin',
-  },
-  {
-    title: 'Prometheus',
-    description: 'Metrics collection, PromQL queries & targets',
-    url: '/prometheus/',
-    badge: 'read-only',
-  },
-  {
-    title: 'Order Service — API Docs',
-    description: 'OpenAPI / Swagger UI for orders & menu endpoints',
-    url: 'http://localhost:8003/docs',
-  },
-  {
-    title: 'Delivery Service — API Docs',
-    description: 'OpenAPI / Swagger UI for delivery endpoints',
-    url: 'http://localhost:8001/docs',
-  },
-  {
-    title: 'Notifications Service — API Docs',
-    description: 'OpenAPI / Swagger UI for notifications endpoints',
-    url: 'http://localhost:8002/docs',
+    heading: 'Service APIs',
+    blurb:
+      'OpenAPI for each service. These are direct ports, so they only resolve when the stack runs locally.',
+    tools: [
+      {
+        title: 'Orders',
+        description: 'Orders and menu endpoints',
+        url: 'http://localhost:8003/docs',
+        badge: ':8003',
+      },
+      {
+        title: 'Delivery',
+        description: 'Delivery endpoints',
+        url: 'http://localhost:8001/docs',
+        badge: ':8001',
+      },
+      {
+        title: 'Notifications',
+        description: 'Notifications and SSE endpoints',
+        url: 'http://localhost:8002/docs',
+        badge: ':8002',
+      },
+    ],
   },
 ];
 
-const DevTools = () => {
-  return (
-    <div className="max-w-5xl mx-auto">
-      <h2 className="text-2xl font-bold mb-6">Dev Tools</h2>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {tools.map((tool) => (
-          <a
-            key={tool.title}
-            href={tool.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block hover:ring-2 hover:ring-blue-500 rounded-xl transition"
-          >
-            <Card className="h-full">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  {tool.title}
-                  <ExternalLink className="h-4 w-4 text-muted-foreground" />
-                </CardTitle>
-                <CardDescription>{tool.description}</CardDescription>
-              </CardHeader>
-              {(tool.credentials || tool.badge) && (
-                <CardContent className="flex gap-2">
-                  {tool.credentials && (
-                    <code className="text-xs bg-muted px-2 py-1 rounded">
-                      {tool.credentials}
-                    </code>
-                  )}
-                  {tool.badge && (
-                    <span className="text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 px-2 py-1 rounded">
-                      {tool.badge}
-                    </span>
-                  )}
-                </CardContent>
-              )}
-            </Card>
-          </a>
-        ))}
-      </div>
+const ToolCard = ({ tool }: { tool: Tool }) => (
+  <a
+    href={tool.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="surface-card group flex flex-col gap-2 p-5 transition-transform duration-200 hover:-translate-y-0.5 active:scale-[0.99]"
+  >
+    <div className="flex items-start justify-between gap-3">
+      <h3 className="font-medium">{tool.title}</h3>
+      <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
     </div>
-  );
-};
+    <p className="text-sm text-muted-foreground">{tool.description}</p>
+    {(tool.badge || tool.credentials) && (
+      <div className="mt-1 flex flex-wrap gap-2">
+        {tool.badge && <span className="label">{tool.badge}</span>}
+        {tool.credentials && (
+          <code className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[0.7rem]">
+            {tool.credentials}
+          </code>
+        )}
+      </div>
+    )}
+  </a>
+);
+
+const DevTools = () => (
+  <div className="flex flex-col gap-10">
+    <header className="flex flex-col gap-3">
+      <p className="label">Dev tools</p>
+      <h1 className="text-[2.8rem] font-semibold leading-[1.2] text-brand">
+        Look inside the running system
+      </h1>
+    </header>
+
+    {groups.map((group) => (
+      <section key={group.heading} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="label">{group.heading}</h2>
+          <p className="max-w-prose text-sm text-muted-foreground">
+            {group.blurb}
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {group.tools.map((tool) => (
+            <ToolCard key={tool.title} tool={tool} />
+          ))}
+        </div>
+      </section>
+    ))}
+  </div>
+);
 
 export default DevTools;

--- a/frontend/src/pages/Menu.tsx
+++ b/frontend/src/pages/Menu.tsx
@@ -1,82 +1,193 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Minus, Plus, AlertCircle } from 'lucide-react';
 import { fetchMenu } from '@/api/ordersService';
 import { MenuItem } from '@/types';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Link } from '@tanstack/react-router';
-import { useCart } from '@/hooks/useCart.ts';
+import { useCart } from '@/hooks/useCart';
+import { cn } from '@/lib/utils';
+
+const currency = (value: number) =>
+  value.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+
+const StockState = ({ stock }: { stock: number }) => {
+  if (stock === 0) {
+    return <span className="text-sm text-destructive">Out of stock</span>;
+  }
+  if (stock <= 3) {
+    return (
+      <span className="numeric text-sm text-muted-foreground">
+        Only {stock} left
+      </span>
+    );
+  }
+  return null;
+};
+
+const QuantityStepper = ({ item }: { item: MenuItem }) => {
+  const { cart, setQuantity } = useCart();
+  const itemId = item._id ?? '';
+  const quantity = cart[itemId]?.quantity ?? 0;
+  const soldOut = item.stock === 0;
+
+  const apply = (next: number) =>
+    setQuantity(itemId, next, {
+      price: item.price,
+      name: item.name,
+      stock: item.stock,
+    });
+
+  if (quantity === 0) {
+    return (
+      <Button
+        variant="outline"
+        disabled={soldOut}
+        onClick={() => apply(1)}
+        className="min-w-24"
+      >
+        {soldOut ? 'Unavailable' : 'Add'}
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1 rounded-full border border-primary p-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 text-primary"
+        aria-label={`Remove one ${item.name}`}
+        onClick={() => apply(quantity - 1)}
+      >
+        <Minus className="h-3.5 w-3.5" />
+      </Button>
+      <span className="numeric w-7 text-center text-sm font-semibold">
+        {quantity}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 text-primary"
+        aria-label={`Add one ${item.name}`}
+        disabled={quantity >= item.stock}
+        onClick={() => apply(quantity + 1)}
+      >
+        <Plus className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+};
+
+const ItemCard = ({ item }: { item: MenuItem }) => {
+  const { cart } = useCart();
+  const inCart = (cart[item._id ?? '']?.quantity ?? 0) > 0;
+
+  return (
+    <li
+      className={cn(
+        'surface-card flex flex-col gap-4 p-5 transition-shadow',
+        item.stock === 0 && 'opacity-60',
+      )}
+    >
+      <div className="flex flex-col gap-1.5">
+        <h3 className="text-lg font-semibold leading-snug">{item.name}</h3>
+        {item.description && (
+          <p className="text-sm text-muted-foreground">{item.description}</p>
+        )}
+        <StockState stock={item.stock} />
+      </div>
+
+      <div className="mt-auto flex items-center justify-between gap-3 pt-1">
+        <span className="numeric text-base font-semibold">
+          {currency(item.price)}
+        </span>
+        <QuantityStepper item={item} />
+      </div>
+
+      {inCart && (
+        <span className="text-sm font-semibold text-primary">In your cart</span>
+      )}
+    </li>
+  );
+};
+
+const MenuSkeleton = () => (
+  <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
+    {Array.from({ length: 6 }).map((_, i) => (
+      <div key={i} className="surface-card h-44 animate-pulse" />
+    ))}
+  </div>
+);
 
 const MenuPage = () => {
   const {
     data: menu,
     isLoading,
     error,
+    refetch,
   } = useQuery<MenuItem[]>({
     queryKey: ['menu'],
     queryFn: fetchMenu,
   });
 
-  const { cart, updateCart } = useCart();
-  const menuItems = Array.isArray(menu) ? menu : [];
-
-  if (isLoading) return <p>Loading menu...</p>;
-  if (error) return <p className="text-red-500">Failed to load menu.</p>;
+  const grouped = useMemo(() => {
+    const items = Array.isArray(menu) ? menu : [];
+    const byCategory = new Map<string, MenuItem[]>();
+    for (const item of items) {
+      const key = item.category || 'Other';
+      byCategory.set(key, [...(byCategory.get(key) ?? []), item]);
+    }
+    return [...byCategory.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }, [menu]);
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">🍔 Menu</h1>
-      {menuItems.length === 0 && (
-        <p className="text-sm text-muted-foreground">
-          No menu items available.
+    <div className="flex flex-col gap-12">
+      <header className="flex max-w-2xl flex-col gap-3">
+        <h1 className="text-[2.8rem] font-semibold leading-[1.2] text-brand">
+          What are you having?
+        </h1>
+        <p className="text-lg leading-relaxed text-muted-foreground">
+          Stock is read from a MongoDB secondary and cached in Redis, so it
+          settles within thirty seconds of a refill.
         </p>
-      )}
-      <div className="grid gap-4">
-        {menuItems.map((item) => (
-          <div
-            key={item._id ?? ''}
-            className="p-4 border rounded-lg shadow flex justify-between items-center"
-          >
-            <div>
-              <h2 className="text-lg font-semibold">
-                {item.name} - ${item.price.toFixed(2)}
-              </h2>
-              <p>Stock: {item.stock}</p>
-            </div>
-            <div className="flex items-center">
-              <Input
-                type="number"
-                min="0"
-                max={item.stock}
-                value={cart[item._id ?? '']?.quantity || 0}
-                onChange={(e) =>
-                  updateCart(
-                    item._id ?? '',
-                    parseInt(e.target.value) || 0,
-                    item.stock,
-                    item.price,
-                  )
-                }
-                className="w-20 text-center"
-              />
-              <Button
-                variant="outline"
-                className="ml-2"
-                disabled={cart[item._id ?? '']?.quantity === 0}
-              >
-                Add to Cart
-              </Button>
-            </div>
-          </div>
-        ))}
-      </div>
+      </header>
 
-      <div className="mt-6 text-center">
-        <Link to="/cart">
-          <Button variant="default" size="lg" className="w-full">
-            🛒 View Cart
+      {isLoading && <MenuSkeleton />}
+
+      {error && (
+        <div className="surface-card flex flex-col items-start gap-3 p-6">
+          <div className="flex items-center gap-2 text-destructive">
+            <AlertCircle className="h-4 w-4" />
+            <p className="font-semibold">The menu could not be loaded</p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            The orders service did not answer. It may still be starting up.
+          </p>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            Try again
           </Button>
-        </Link>
-      </div>
+        </div>
+      )}
+
+      {!isLoading && !error && grouped.length === 0 && (
+        <div className="surface-card p-10 text-center">
+          <p className="font-semibold">The menu is empty</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Nothing has been seeded into the database yet.
+          </p>
+        </div>
+      )}
+
+      {grouped.map(([category, items]) => (
+        <section key={category} className="flex flex-col gap-5">
+          <h2 className="label">{category}</h2>
+          <ul className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {items.map((item) => (
+              <ItemCard key={item._id ?? item.name} item={item} />
+            ))}
+          </ul>
+        </section>
+      ))}
     </div>
   );
 };

--- a/frontend/src/pages/Order.tsx
+++ b/frontend/src/pages/Order.tsx
@@ -1,26 +1,37 @@
-import { useNavigate } from '@tanstack/react-router';
+import { useRef, useState } from 'react';
+import { useNavigate, Link } from '@tanstack/react-router';
 import { useMutation } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
+import { AlertCircle, Info, Loader2 } from 'lucide-react';
 import { createOrder } from '@/api/ordersService';
 import { Order, OrderingPerson, OrderResponse } from '@/types';
-import { useRef, useState } from 'react';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
-import { useCart } from '@/hooks/useCart';
-import { orderSchema } from '@/validation/orderSchema';
-import { Info } from 'lucide-react';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { useCart } from '@/hooks/useCart';
+import { orderSchema } from '@/validation/orderSchema';
+import { cn } from '@/lib/utils';
+
+const currency = (value: number) =>
+  value.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+
+const fields = [
+  { key: 'first_name', label: 'First name', autoComplete: 'given-name' },
+  { key: 'last_name', label: 'Last name', autoComplete: 'family-name' },
+  { key: 'address', label: 'Delivery address', autoComplete: 'street-address' },
+  { key: 'phone_number', label: 'Phone number', autoComplete: 'tel' },
+] as const;
 
 const OrderPage = () => {
   const navigate = useNavigate();
-  const { cart, clearCart } = useCart();
+  const { lines, totalPrice, clearCart } = useCart();
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const [person, setPerson] = useState<OrderingPerson>({
     first_name: '',
@@ -29,7 +40,7 @@ const OrderPage = () => {
     phone_number: '',
   });
 
-  const [simulationChecked, setSimulationChecked] = useState(false);
+  const [simulationChecked, setSimulationChecked] = useState(true);
 
   // Held across retries of one checkout attempt, so a lost response or a
   // dropped connection cannot turn into a second order. Cleared once an order
@@ -45,10 +56,11 @@ const OrderPage = () => {
       idempotencyKey.current = null;
       const orderId = data.order._id;
       if (!orderId) {
-        alert('Order placed, but order ID is missing in the response.');
+        setSubmitError(
+          'The order was placed, but the response carried no order id, so it cannot be tracked.',
+        );
         return;
       }
-      alert(`✅ Order placed successfully! Order ID: ${orderId}`);
       clearCart();
       await navigate({ to: '/tracking/' + orderId });
     },
@@ -56,31 +68,27 @@ const OrderPage = () => {
       // 409 means the previous attempt with this key is still in flight, so
       // the key is kept and retrying resolves to that attempt's result.
       if (isAxiosError(error) && error.response?.status === 409) {
-        alert('That order is still being placed. Try again in a moment.');
+        setSubmitError(
+          'That order is still being placed. Retry in a moment to pick up the original result.',
+        );
         return;
       }
-      if (error instanceof Error) {
-        alert(`Failed to place order: ${error.message}`);
-      } else {
-        alert('An unknown error occurred.');
-      }
+      setSubmitError(
+        error instanceof Error
+          ? error.message
+          : 'The order could not be placed.',
+      );
     },
   });
 
-  const validCart = Object.entries(cart).filter(
-    ([, item]) => item.quantity > 0,
-  );
-  const totalPrice = validCart.reduce(
-    (acc, [, item]) => acc + item.quantity * item.price,
-    0,
-  );
-
   const handleOrder = () => {
+    setSubmitError(null);
+
     const validationResult = orderSchema.safeParse({
       person,
-      items: validCart.map(([itemId, item]) => ({
-        item_id: itemId,
-        quantity: item.quantity,
+      items: lines.map((line) => ({
+        item_id: line.itemId,
+        quantity: line.quantity,
       })),
     });
 
@@ -93,114 +101,179 @@ const OrderPage = () => {
       return;
     }
 
-    if (validCart.length === 0) {
-      alert('Cannot place an order with an empty cart!');
-      return;
-    }
+    setErrors({});
 
-    const newOrder: Order = {
+    mutation.mutate({
       person,
-      items: validCart.map(([itemId, item]) => ({
-        item_id: itemId,
-        quantity: item.quantity,
+      items: lines.map((line) => ({
+        item_id: line.itemId,
+        quantity: line.quantity,
       })),
       simulation: simulationChecked ? 1 : -1,
-    };
-
-    mutation.mutate(newOrder);
+    });
   };
 
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">🛒 Confirm Order</h1>
-
-      {validCart.length === 0 ? (
-        <p className="text-red-500 mt-4">
-          ❌ Your cart is empty. Add items before placing an order.
-        </p>
-      ) : (
-        <Card className="p-4 mt-4">
-          <h2 className="text-lg font-semibold">Order Summary</h2>
-          {validCart.map(([itemId, item]) => (
-            <p key={itemId}>
-              Item {itemId}: {item.quantity} pcs - ${item.price.toFixed(2)} each
-            </p>
-          ))}
-          <Separator className="my-2" />
-          <h3 className="text-lg font-bold">Total: ${totalPrice.toFixed(2)}</h3>
-        </Card>
-      )}
-
-      <div className="mt-4 space-y-2">
-        <Input
-          placeholder="First Name"
-          value={person.first_name}
-          onChange={(e) => setPerson({ ...person, first_name: e.target.value })}
-        />
-        {errors['person.first_name'] && (
-          <p className="text-red-500">{errors['person.first_name']}</p>
-        )}
-
-        <Input
-          placeholder="Last Name"
-          value={person.last_name}
-          onChange={(e) => setPerson({ ...person, last_name: e.target.value })}
-        />
-        {errors['person.last_name'] && (
-          <p className="text-red-500">{errors['person.last_name']}</p>
-        )}
-
-        <Input
-          placeholder="Address"
-          value={person.address}
-          onChange={(e) => setPerson({ ...person, address: e.target.value })}
-        />
-        {errors['person.address'] && (
-          <p className="text-red-500">{errors['person.address']}</p>
-        )}
-
-        <Input
-          placeholder="Phone Number"
-          value={person.phone_number}
-          onChange={(e) =>
-            setPerson({ ...person, phone_number: e.target.value })
-          }
-        />
-        {errors['person.phone_number'] && (
-          <p className="text-red-500">{errors['person.phone_number']}</p>
-        )}
-
-        <div className="flex items-center space-x-2 mt-2">
-          <input
-            type="checkbox"
-            id="simulation-checkbox"
-            checked={simulationChecked}
-            onChange={(e) => setSimulationChecked(e.target.checked)}
-          />
-          <label htmlFor="simulation-checkbox" className="text-sm">
-            Enable Simulation
-          </label>
-          <Popover>
-            <PopoverTrigger asChild>
-              <Info className="h-4 w-4 text-gray-500 cursor-pointer" />
-            </PopoverTrigger>
-            <PopoverContent className="p-2">
-              <p className="text-sm">
-                During the simulation you'll see real-time updates of your
-                order's journey.
-              </p>
-            </PopoverContent>
-          </Popover>
+  if (lines.length === 0) {
+    return (
+      <div className="flex flex-col gap-8">
+        <h1 className="text-[2.8rem] font-semibold leading-[1.2] text-brand">
+          There is nothing to order
+        </h1>
+        <div className="surface-card flex flex-col items-start gap-5 p-8">
+          <p className="text-muted-foreground">
+            Add something from the menu first.
+          </p>
+          <Link to="/">
+            <Button variant="outline">Back to the menu</Button>
+          </Link>
         </div>
       </div>
+    );
+  }
 
-      <Button
-        className="w-full mt-4 bg-green-600 hover:bg-green-700 text-white"
-        onClick={handleOrder}
-        disabled={mutation.isPending || validCart.length === 0}
-      >
-        {mutation.isPending ? 'Placing Order...' : '✅ Confirm Order'}
-      </Button>
+  return (
+    <div className="flex flex-col gap-8">
+      <h1 className="text-[2.8rem] font-semibold leading-[1.2] text-brand">
+        Where is this going?
+      </h1>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_340px] lg:items-start">
+        <form
+          className="surface-card flex flex-col gap-6 p-6 sm:p-7"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleOrder();
+          }}
+          noValidate
+        >
+          <div className="grid gap-5 sm:grid-cols-2">
+            {fields.map((field) => {
+              const errorKey = `person.${field.key}`;
+              const invalid = Boolean(errors[errorKey]);
+              return (
+                <div
+                  key={field.key}
+                  className={cn(
+                    'flex flex-col gap-1.5',
+                    field.key === 'address' && 'sm:col-span-2',
+                  )}
+                >
+                  <Label htmlFor={field.key}>{field.label}</Label>
+                  <Input
+                    id={field.key}
+                    autoComplete={field.autoComplete}
+                    aria-invalid={invalid}
+                    aria-describedby={
+                      invalid ? `${field.key}-error` : undefined
+                    }
+                    value={person[field.key]}
+                    onChange={(e) =>
+                      setPerson({ ...person, [field.key]: e.target.value })
+                    }
+                    className={cn(invalid && 'border-destructive')}
+                  />
+                  {invalid && (
+                    <p
+                      id={`${field.key}-error`}
+                      className="text-xs text-destructive"
+                    >
+                      {errors[errorKey]}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="flex items-start gap-3 rounded-lg bg-accent/50 p-4">
+            <input
+              type="checkbox"
+              id="simulation-checkbox"
+              checked={simulationChecked}
+              onChange={(e) => setSimulationChecked(e.target.checked)}
+              className="mt-0.5 h-4 w-4 accent-[var(--primary)]"
+            />
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-1.5">
+                <Label htmlFor="simulation-checkbox" className="cursor-pointer">
+                  Simulate the delivery
+                </Label>
+                <Popover>
+                  <PopoverTrigger
+                    aria-label="What the simulation does"
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </PopoverTrigger>
+                  <PopoverContent className="text-sm">
+                    The simulator advances the order through its lifecycle on
+                    durable timers, so you can watch the status arrive over SSE
+                    in real time.
+                  </PopoverContent>
+                </Popover>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Drives the order through every status so you can watch tracking
+                update live.
+              </p>
+            </div>
+          </div>
+
+          {submitError && (
+            <div
+              role="alert"
+              className="flex items-start gap-2 rounded-lg bg-destructive/5 p-4 text-sm text-destructive"
+            >
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>{submitError}</p>
+            </div>
+          )}
+
+          <Button
+            type="submit"
+            size="lg"
+            disabled={mutation.isPending}
+            className="w-full"
+          >
+            {mutation.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            {mutation.isPending ? 'Placing order' : 'Place order'}
+          </Button>
+
+          <p className="label">
+            Sent with an Idempotency-Key — retrying returns the original order
+            rather than placing a second one.
+          </p>
+        </form>
+
+        <aside className="surface-card flex flex-col gap-5 p-6 lg:sticky lg:top-24">
+          <h2 className="label">Order summary</h2>
+
+          <ul className="flex flex-col gap-2.5 text-sm">
+            {lines.map((line) => (
+              <li key={line.itemId} className="flex justify-between gap-3">
+                <span className="min-w-0">
+                  <span className="numeric text-muted-foreground">
+                    {line.quantity}×
+                  </span>{' '}
+                  {line.name || 'Unnamed item'}
+                </span>
+                <span className="numeric shrink-0">
+                  {currency(line.price * line.quantity)}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex items-baseline justify-between border-t border-border pt-5">
+            <span className="font-semibold">Total</span>
+            <span className="numeric text-xl font-semibold">
+              {currency(totalPrice)}
+            </span>
+          </div>
+        </aside>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/OrderTracking.tsx
+++ b/frontend/src/pages/OrderTracking.tsx
@@ -5,7 +5,7 @@ export default function OrderTrackingPage() {
   const { order_id } = useParams({ from: '/tracking/$order_id' });
 
   return (
-    <div className="flex justify-center items-center min-h-screen">
+    <div className="mx-auto w-full max-w-3xl">
       <OrderTracker orderId={order_id} />
     </div>
   );

--- a/frontend/src/store/cart-context.ts
+++ b/frontend/src/store/cart-context.ts
@@ -1,0 +1,27 @@
+import { createContext } from 'react';
+
+export interface CartLine {
+  quantity: number;
+  price: number;
+  name: string;
+  stock: number;
+}
+
+export type Cart = Record<string, CartLine>;
+
+export interface CartContextValue {
+  cart: Cart;
+  lines: Array<CartLine & { itemId: string }>;
+  itemCount: number;
+  totalPrice: number;
+  setQuantity: (
+    itemId: string,
+    quantity: number,
+    line: Omit<CartLine, 'quantity'>,
+  ) => void;
+  clearCart: () => void;
+}
+
+export const CART_STORAGE_KEY = 'cart';
+
+export const CartContext = createContext<CartContextValue | null>(null);

--- a/frontend/src/store/cart.tsx
+++ b/frontend/src/store/cart.tsx
@@ -1,0 +1,81 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  CartContext,
+  CART_STORAGE_KEY,
+  type Cart,
+  type CartContextValue,
+  type CartLine,
+} from '@/store/cart-context';
+
+const readStoredCart = (): Cart => {
+  try {
+    const saved = localStorage.getItem(CART_STORAGE_KEY);
+    if (!saved) return {};
+    const parsed: unknown = JSON.parse(saved);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed as Cart;
+  } catch {
+    // A corrupt entry should not take the whole app down with it.
+    return {};
+  }
+};
+
+export const CartProvider = ({ children }: { children: ReactNode }) => {
+  // One instance for the whole tree, so the header badge and the menu page
+  // are looking at the same cart.
+  const [cart, setCart] = useState<Cart>(readStoredCart);
+
+  useEffect(() => {
+    localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(cart));
+  }, [cart]);
+
+  const setQuantity = useCallback(
+    (itemId: string, quantity: number, line: Omit<CartLine, 'quantity'>) => {
+      if (!itemId) return;
+
+      const safeQuantity = Math.max(0, Math.min(quantity, line.stock));
+
+      setCart((prev) => {
+        const next = { ...prev };
+        if (safeQuantity > 0) {
+          next[itemId] = { ...line, quantity: safeQuantity };
+        } else {
+          delete next[itemId];
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const clearCart = useCallback(() => {
+    setCart({});
+    localStorage.removeItem(CART_STORAGE_KEY);
+  }, []);
+
+  const value = useMemo<CartContextValue>(() => {
+    const lines = Object.entries(cart)
+      .filter(([, line]) => line.quantity > 0)
+      .map(([itemId, line]) => ({ itemId, ...line }));
+
+    return {
+      cart,
+      lines,
+      itemCount: lines.reduce((sum, line) => sum + line.quantity, 0),
+      totalPrice: lines.reduce(
+        (sum, line) => sum + line.quantity * line.price,
+        0,
+      ),
+      setQuantity,
+      clearCart,
+    };
+  }, [cart, setQuantity, clearCart]);
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+};

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -6,6 +6,10 @@ upstream notifications_api {
     server notifications-service:8002;
 }
 
+upstream frontend_app {
+    server frontend:80;
+}
+
 limit_req_zone $binary_remote_addr zone=api_limit:10m rate=30r/s;
 
 server {
@@ -61,8 +65,8 @@ server {
         proxy_send_timeout 3600s;
     }
 
-    # Deny everything else
+    # Static frontend, served by the frontend image's own nginx
     location / {
-        return 404;
+        proxy_pass http://frontend_app;
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orders-project-workspace"
-version = "0.2.1"
+version = "0.3.0"
 description = "Workspace root for all Python services"
 requires-python = ">=3.13"
 dependencies = []


### PR DESCRIPTION
The prod nginx config never had a route for the frontend — location / returned
404 — so nothing served the SPA behind the proxy. Add the frontend upstream.

The cart hook held its own useState per component, so the header badge and the
menu page were looking at different carts, and lines carried no item name,
which left the cart and checkout listing raw object ids. Move the cart into a
provider and store the name, price and stock with each line.

Restyle every page against a token system: warm canvas, four brand tiers with
distinct surface roles, pill buttons with a scale(0.95) press, 12px cards with
layered shadows. Replace alert() with inline states, group the menu by
category, and surface the SSE connection state and event log on tracking.
