### PR TITLE
Format index.css and ignore the local design reference

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,5 @@
+dist
+node_modules
+
+# Local-only design reference, kept out of the repo
+DESIGN.md

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,7 +55,8 @@
     0 1px 3px rgba(0, 0, 0, 0.1), 0 2px 2px rgba(0, 0, 0, 0.06),
     0 0 2px rgba(0, 0, 0, 0.07);
   --shadow-float: 0 0 6px rgba(0, 0, 0, 0.24), 0 8px 12px rgba(0, 0, 0, 0.14);
-  --shadow-float-active: 0 0 6px rgba(0, 0, 0, 0.24), 0 8px 12px rgba(0, 0, 0, 0);
+  --shadow-float-active:
+    0 0 6px rgba(0, 0, 0, 0.24), 0 8px 12px rgba(0, 0, 0, 0);
 }
 
 .dark {
@@ -90,13 +91,13 @@
   --input: rgba(255, 255, 255, 0.32);
   --ring: #ffffff;
 
-  --shadow-card:
-    0 0 0.5px 0 rgba(0, 0, 0, 0.3), 0 1px 1px 0 rgba(0, 0, 0, 0.4);
+  --shadow-card: 0 0 0.5px 0 rgba(0, 0, 0, 0.3), 0 1px 1px 0 rgba(0, 0, 0, 0.4);
   --shadow-nav:
     0 1px 3px rgba(0, 0, 0, 0.3), 0 2px 2px rgba(0, 0, 0, 0.2),
     0 0 2px rgba(0, 0, 0, 0.2);
   --shadow-float: 0 0 6px rgba(0, 0, 0, 0.4), 0 8px 12px rgba(0, 0, 0, 0.3);
-  --shadow-float-active: 0 0 6px rgba(0, 0, 0, 0.4), 0 8px 12px rgba(0, 0, 0, 0);
+  --shadow-float-active:
+    0 0 6px rgba(0, 0, 0, 0.4), 0 8px 12px rgba(0, 0, 0, 0);
 }
 
 @theme inline {
@@ -137,8 +138,8 @@
 
   --font-sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --font-mono:
-    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
-    'Liberation Mono', monospace;
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
 }
 
 @layer base {


### PR DESCRIPTION
The CSS was not covered by eslint --fix, so prettier --check failed on master.
Add a .prettierignore so the untracked local DESIGN.md does not fail the check
for anyone running prettier locally.
