### PR TITLE
Keep Prometheus scrapes out of the RED metrics

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -3,18 +3,26 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
+  # The FastAPI services mount the metrics app at /metrics, and a Starlette
+  # mount redirects /metrics to /metrics/. Scraping the trailing-slash path
+  # directly avoids paying for a 307 on every scrape.
   - job_name: "order-service"
+    metrics_path: /metrics/
     static_configs:
       - targets: ["order-service:8003"]
 
   - job_name: "delivery-service"
+    metrics_path: /metrics/
     static_configs:
       - targets: ["delivery-service:8001"]
 
   - job_name: "notifications-service"
+    metrics_path: /metrics/
     static_configs:
       - targets: ["notifications-service:8002"]
 
+  # The simulator serves metrics from prometheus_client's own HTTP server,
+  # which has no mount and therefore no redirect.
   - job_name: "order-simulator"
     static_configs:
       - targets: ["order-simulator:9090"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orders-project-workspace"
-version = "0.3.1"
+version = "0.3.2"
 description = "Workspace root for all Python services"
 requires-python = ">=3.13"
 dependencies = []

--- a/shared/src/shared/http_metrics.py
+++ b/shared/src/shared/http_metrics.py
@@ -25,7 +25,10 @@ class PrometheusMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http" or scope.get("path") == "/metrics":
+        # The metrics app is mounted at /metrics, so it is actually served from
+        # /metrics/. Matching the prefix keeps scrapes out of the RED metrics
+        # they are meant to report on.
+        if scope["type"] != "http" or scope.get("path", "").startswith("/metrics"):
             await self.app(scope, receive, send)
             return
 


### PR DESCRIPTION
The metrics app is mounted at /metrics, so Starlette serves it from /metrics/
and redirects the bare path. The middleware excluded only the exact /metrics,
which meant every scrape landed in the request counters the dashboards read —
at a 15s interval that is most of the traffic those panels showed.

Match the prefix instead, and point the three FastAPI scrape jobs straight at
/metrics/ so each scrape stops paying for a 307. The simulator keeps the bare
path: it serves metrics from prometheus_client's own server, with no mount.
