### PR TITLE
Start nginx after the upstreams it proxies

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -212,6 +212,12 @@ services:
         condition: service_healthy
       frontend:
         condition: service_started
+      # nginx resolves every upstream host at startup and refuses to boot if
+      # one is missing, so the proxied observability targets must exist first.
+      grafana:
+        condition: service_started
+      prometheus:
+        condition: service_started
     networks:
       - backend_net
       - frontend_net


### PR DESCRIPTION
nginx resolves every upstream host once, at startup, and exits if a name does
not resolve. The prod config proxies Grafana and Prometheus but the proxy only
waited on the application services, so a slow or failed monitoring container
took the whole edge down with a host-not-found error.
