### PR TITLE
Replace the dev tools link list with an animated flow diagram

### DIFF
--- a/frontend/src/components/SystemFlow.tsx
+++ b/frontend/src/components/SystemFlow.tsx
@@ -1,0 +1,503 @@
+import { useEffect, useState } from 'react';
+import { Pause, Play } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Walks one order through the system, one hop at a time. Every stream and
+ * event name here is the one the services actually use.
+ */
+
+interface Step {
+  id: string;
+  title: string;
+  caption: string;
+  /** Edge ids lit for this step. */
+  edges: string[];
+  /** Node ids lit for this step. */
+  nodes: string[];
+}
+
+const steps: Step[] = [
+  {
+    id: 'place',
+    title: 'The order arrives',
+    caption:
+      'POST /orders carries an Idempotency-Key. The key is reserved inside the order transaction, so a client that times out and retries gets its original order back instead of a second one.',
+    edges: ['browser-nginx', 'nginx-orders'],
+    nodes: ['browser', 'nginx', 'orders'],
+  },
+  {
+    id: 'commit',
+    title: 'One transaction, two writes',
+    caption:
+      'The order and its outbox row commit together. After the commit the event cannot be missing — which is what makes publishing afterwards safe.',
+    edges: ['orders-mongo'],
+    nodes: ['orders', 'mongo'],
+  },
+  {
+    id: 'publish',
+    title: 'The relay publishes',
+    caption:
+      'A relay tails the outbox by change stream, with a 30-second sweep behind it for correctness, and publishes order.created.v1 to orders-stream.',
+    edges: ['orders-stream'],
+    nodes: ['orders', 'orders-stream'],
+  },
+  {
+    id: 'react',
+    title: 'Whoever cares, reacts',
+    caption:
+      'Delivery and Notifications each consume orders-stream as a group member. Delivery writes its own record and publishes delivery.created.v1 to deliveries-stream.',
+    edges: ['stream-delivery', 'delivery-deliveries', 'stream-notifications'],
+    nodes: ['orders-stream', 'delivery', 'deliveries-stream', 'notifications'],
+  },
+  {
+    id: 'simulate',
+    title: 'Durable timers move it along',
+    caption:
+      'The simulator advances the order through its lifecycle. Steps are rows in a Redis sorted set claimed atomically by Lua, so a restart resumes rather than stranding the order.',
+    edges: ['simulator-redis'],
+    nodes: ['simulator', 'deliveries-stream'],
+  },
+  {
+    id: 'push',
+    title: 'Every replica gets the push',
+    caption:
+      'A domain event reaches exactly one Notifications replica, so it republishes to ws-events, which is consumed by a group per replica. Each replica then pushes over SSE to the clients it actually holds.',
+    edges: ['notif-ws', 'notif-browser'],
+    nodes: ['notifications', 'ws-events', 'browser'],
+  },
+];
+
+const STEP_MS = 4200;
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const SystemFlow = () => {
+  const reduced = prefersReducedMotion();
+  const [active, setActive] = useState(0);
+  const [playing, setPlaying] = useState(!reduced);
+
+  useEffect(() => {
+    if (!playing) return;
+    const timer = setInterval(
+      () => setActive((i) => (i + 1) % steps.length),
+      STEP_MS,
+    );
+    return () => clearInterval(timer);
+  }, [playing]);
+
+  const step = steps[active];
+  const edgeOn = (id: string) => step.edges.includes(id);
+  const nodeOn = (id: string) => step.nodes.includes(id);
+
+  const edge = (id: string) =>
+    cn(
+      'flow-edge',
+      edgeOn(id) && 'flow-edge-on',
+      !reduced && edgeOn(id) && 'flow-edge-live',
+    );
+  const node = (id: string) => cn('flow-node', nodeOn(id) && 'flow-node-on');
+  const nodeText = (id: string) =>
+    cn('flow-node-label', nodeOn(id) && 'flow-node-label-on');
+
+  return (
+    <section className="flex flex-col gap-5">
+      <div className="surface-card overflow-x-auto p-4 sm:p-6">
+        <svg
+          viewBox="0 0 1000 600"
+          role="img"
+          aria-label="An order enters through NGINX to the orders service, commits with its outbox row to MongoDB, is published to orders-stream in Redis, consumed by delivery and notifications, advanced by the simulator on durable timers, and pushed back to the browser over SSE."
+          className="w-full min-w-[760px]"
+        >
+          <defs>
+            <marker
+              id="fa"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="7"
+              markerHeight="7"
+              orient="auto-start-reverse"
+            >
+              <path d="M0 0 L10 5 L0 10 z" className="flow-arrow" />
+            </marker>
+          </defs>
+
+          {/* Redis enclosure */}
+          <rect
+            x="530"
+            y="30"
+            width="222"
+            height="310"
+            rx="8"
+            className="flow-enclosure"
+          />
+          <text x="538" y="22" className="flow-caption">
+            REDIS
+          </text>
+
+          {/* ---------- edges ---------- */}
+          <path
+            d="M150 248 H184"
+            className={edge('browser-nginx')}
+            markerEnd="url(#fa)"
+          />
+          <path
+            d="M240 220 V78 H334"
+            className={edge('nginx-orders')}
+            markerEnd="url(#fa)"
+          />
+          <text x="250" y="150" className="flow-caption">
+            POST /orders
+          </text>
+
+          <path
+            d="M405 106 V350 H855 V338"
+            className={edge('orders-mongo')}
+            markerEnd="url(#fa)"
+          />
+          <text x="600" y="366" className="flow-caption">
+            order + outbox, one transaction
+          </text>
+
+          <path
+            d="M470 78 H539"
+            className={edge('orders-stream')}
+            markerEnd="url(#fa)"
+          />
+
+          <path
+            d="M735 99 H794"
+            className={edge('stream-delivery')}
+            markerEnd="url(#fa)"
+          />
+          <text x="742" y="90" className="flow-caption">
+            group
+          </text>
+
+          <path
+            d="M830 106 V184 H739"
+            className={edge('delivery-deliveries')}
+            markerEnd="url(#fa)"
+          />
+
+          <path
+            d="M545 99 H505 V392 H424"
+            className={edge('stream-notifications')}
+            markerEnd="url(#fa)"
+          />
+          <text x="452" y="384" className="flow-caption">
+            group
+          </text>
+
+          <path
+            d="M800 420 H770 V336"
+            className={cn(edge('simulator-redis'), 'flow-edge-dashed')}
+            markerEnd="url(#fa)"
+          />
+          <text x="700" y="440" className="flow-caption">
+            durable timers
+          </text>
+
+          <path
+            d="M490 428 H640 V292"
+            className={edge('notif-ws')}
+            markerEnd="url(#fa)"
+            markerStart="url(#fa)"
+          />
+          <text x="556" y="420" className="flow-caption">
+            fan-out, one group per replica
+          </text>
+
+          <path
+            d="M340 428 H90 V284"
+            className={cn(edge('notif-browser'), 'flow-edge-dashed')}
+            markerEnd="url(#fa)"
+          />
+          <text x="150" y="450" className="flow-caption">
+            SSE push
+          </text>
+
+          {/* ---------- nodes ---------- */}
+          <g>
+            <rect
+              x="30"
+              y="220"
+              width="120"
+              height="56"
+              rx="6"
+              className={node('browser')}
+            />
+            <text
+              x="90"
+              y="245"
+              textAnchor="middle"
+              className={nodeText('browser')}
+            >
+              Browser
+            </text>
+            <text x="90" y="262" textAnchor="middle" className="flow-caption">
+              React
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="190"
+              y="220"
+              width="100"
+              height="56"
+              rx="6"
+              className={node('nginx')}
+            />
+            <text
+              x="240"
+              y="245"
+              textAnchor="middle"
+              className={nodeText('nginx')}
+            >
+              NGINX
+            </text>
+            <text x="240" y="262" textAnchor="middle" className="flow-caption">
+              :80
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="340"
+              y="50"
+              width="130"
+              height="56"
+              rx="6"
+              className={node('orders')}
+            />
+            <text
+              x="405"
+              y="75"
+              textAnchor="middle"
+              className={nodeText('orders')}
+            >
+              Orders
+            </text>
+            <text x="405" y="92" textAnchor="middle" className="flow-caption">
+              :8003
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="800"
+              y="50"
+              width="130"
+              height="56"
+              rx="6"
+              className={node('delivery')}
+            />
+            <text
+              x="865"
+              y="75"
+              textAnchor="middle"
+              className={nodeText('delivery')}
+            >
+              Delivery
+            </text>
+            <text x="865" y="92" textAnchor="middle" className="flow-caption">
+              :8001
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="340"
+              y="400"
+              width="150"
+              height="56"
+              rx="6"
+              className={node('notifications')}
+            />
+            <text
+              x="415"
+              y="425"
+              textAnchor="middle"
+              className={nodeText('notifications')}
+            >
+              Notifications
+            </text>
+            <text x="415" y="442" textAnchor="middle" className="flow-caption">
+              :8002
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="800"
+              y="400"
+              width="130"
+              height="56"
+              rx="6"
+              className={node('simulator')}
+            />
+            <text
+              x="865"
+              y="425"
+              textAnchor="middle"
+              className={nodeText('simulator')}
+            >
+              Simulator
+            </text>
+            <text x="865" y="442" textAnchor="middle" className="flow-caption">
+              Lua + ZSET
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="780"
+              y="274"
+              width="160"
+              height="64"
+              rx="6"
+              className={node('mongo')}
+            />
+            <text
+              x="860"
+              y="300"
+              textAnchor="middle"
+              className={nodeText('mongo')}
+            >
+              MongoDB rs0
+            </text>
+            <circle cx="836" cy="318" r="4.5" className="flow-primary-dot" />
+            <circle cx="854" cy="318" r="4.5" className="flow-member-dot" />
+            <circle cx="872" cy="318" r="4.5" className="flow-member-dot" />
+          </g>
+
+          <g>
+            <rect
+              x="545"
+              y="80"
+              width="190"
+              height="38"
+              rx="19"
+              className={node('orders-stream')}
+            />
+            <text
+              x="640"
+              y="104"
+              textAnchor="middle"
+              className={nodeText('orders-stream')}
+            >
+              orders-stream
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="545"
+              y="165"
+              width="190"
+              height="38"
+              rx="19"
+              className={node('deliveries-stream')}
+            />
+            <text
+              x="640"
+              y="189"
+              textAnchor="middle"
+              className={nodeText('deliveries-stream')}
+            >
+              deliveries-stream
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="545"
+              y="254"
+              width="190"
+              height="38"
+              rx="19"
+              className={node('ws-events')}
+            />
+            <text
+              x="640"
+              y="278"
+              textAnchor="middle"
+              className={nodeText('ws-events')}
+            >
+              ws-events
+            </text>
+          </g>
+
+          <g>
+            <rect
+              x="545"
+              y="302"
+              width="190"
+              height="30"
+              rx="15"
+              className="flow-node flow-node-muted"
+            />
+            <text x="640" y="322" textAnchor="middle" className="flow-caption">
+              dead-letters
+            </text>
+          </g>
+        </svg>
+      </div>
+
+      {/* ---------- narration ---------- */}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center gap-2">
+          {steps.map((s, i) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => {
+                setActive(i);
+                setPlaying(false);
+              }}
+              aria-current={i === active}
+              className={cn(
+                'rounded-full px-3 py-1.5 text-xs font-semibold transition-colors',
+                i === active
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {i + 1}. {s.title}
+            </button>
+          ))}
+
+          <button
+            type="button"
+            onClick={() => setPlaying((p) => !p)}
+            aria-label={
+              playing ? 'Pause the walkthrough' : 'Play the walkthrough'
+            }
+            className="ml-auto flex items-center gap-1.5 rounded-full border border-foreground/30 px-3 py-1.5 text-xs font-semibold transition-all active:scale-95"
+          >
+            {playing ? (
+              <>
+                <Pause className="h-3 w-3" /> Pause
+              </>
+            ) : (
+              <>
+                <Play className="h-3 w-3" /> Play
+              </>
+            )}
+          </button>
+        </div>
+
+        <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">
+          <span className="font-semibold text-foreground">{step.title}.</span>{' '}
+          {step.caption}
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default SystemFlow;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -173,6 +173,95 @@
     border-radius: var(--radius);
     box-shadow: var(--shadow-card);
   }
+
+  /* ---------- system flow diagram ---------- */
+  .flow-edge {
+    fill: none;
+    stroke: color-mix(in srgb, var(--foreground) 20%, transparent);
+    stroke-width: 1.5;
+    transition:
+      stroke 0.4s ease,
+      stroke-width 0.4s ease;
+  }
+
+  .flow-edge-dashed {
+    stroke-dasharray: 5 5;
+  }
+
+  .flow-edge-on {
+    stroke: var(--primary);
+    stroke-width: 2.2;
+  }
+
+  /* Only the lit hop animates, so the eye follows one thing at a time. */
+  .flow-edge-live {
+    stroke-dasharray: 8 12;
+    animation: flow-dash 1.1s linear infinite;
+  }
+
+  @keyframes flow-dash {
+    to {
+      stroke-dashoffset: -20;
+    }
+  }
+
+  .flow-arrow {
+    fill: color-mix(in srgb, var(--foreground) 35%, transparent);
+  }
+
+  .flow-enclosure {
+    fill: none;
+    stroke: color-mix(in srgb, var(--foreground) 15%, transparent);
+    stroke-width: 1.2;
+    stroke-dasharray: 3 5;
+  }
+
+  .flow-node {
+    fill: var(--card);
+    stroke: color-mix(in srgb, var(--foreground) 18%, transparent);
+    stroke-width: 1.4;
+    transition:
+      stroke 0.4s ease,
+      fill 0.4s ease,
+      stroke-width 0.4s ease;
+  }
+
+  .flow-node-on {
+    stroke: var(--primary);
+    stroke-width: 2;
+    fill: color-mix(in srgb, var(--primary) 10%, var(--card));
+  }
+
+  .flow-node-muted {
+    opacity: 0.5;
+  }
+
+  .flow-node-label {
+    font-size: 13px;
+    font-weight: 600;
+    fill: var(--foreground);
+    transition: fill 0.4s ease;
+  }
+
+  .flow-node-label-on {
+    fill: var(--primary);
+  }
+
+  .flow-caption {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    fill: var(--muted-foreground);
+  }
+
+  .flow-primary-dot {
+    fill: var(--primary);
+  }
+
+  .flow-member-dot {
+    fill: none;
+    stroke: var(--muted-foreground);
+    stroke-width: 1.2;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/pages/DevTools.tsx
+++ b/frontend/src/pages/DevTools.tsx
@@ -1,88 +1,95 @@
 import { ExternalLink } from 'lucide-react';
+import SystemFlow from '@/components/SystemFlow';
 
 interface Tool {
   title: string;
   description: string;
   url: string;
-  badge?: string;
-  credentials?: string;
+  note?: string;
 }
 
-interface ToolGroup {
-  heading: string;
-  blurb: string;
-  tools: Tool[];
-  /** Direct service ports only resolve for someone sitting at the machine. */
-  localOnly?: boolean;
-}
-
-const isLocal = ['localhost', '127.0.0.1'].includes(
-  typeof window === 'undefined' ? '' : window.location.hostname,
-);
-
-const groups: ToolGroup[] = [
+const dashboards: Tool[] = [
   {
-    heading: 'Dashboards',
-    blurb:
-      'Prometheus scrapes RED metrics and per-stream consumer lag; Loki holds the logs, keyed by correlation id.',
-    tools: [
-      {
-        title: 'HTTP metrics',
-        description: 'Request rate, latency percentiles and error rates',
-        url: '/grafana/d/http-metrics/http-metrics',
-        badge: 'read-only',
-      },
-      {
-        title: 'Application logs',
-        description: 'Live log stream, volume and error tracking (Loki)',
-        url: '/grafana/d/application-logs/application-logs',
-        badge: 'read-only',
-      },
-      {
-        title: 'Event pipeline',
-        description: 'Stream throughput, processing latency and dead letters',
-        url: '/grafana/d/event-pipeline/event-pipeline',
-        badge: 'read-only',
-      },
-      {
-        title: 'Grafana',
-        description: 'All dashboards, explore and admin',
-        url: '/grafana/',
-        credentials: 'admin / admin',
-      },
-      {
-        title: 'Prometheus',
-        description: 'Metrics collection, PromQL queries and targets',
-        url: '/prometheus/',
-        badge: 'read-only',
-      },
-    ],
+    title: 'HTTP metrics',
+    description:
+      'Request rate, latency percentiles and error rates per service',
+    url: '/grafana/d/http-metrics/http-metrics',
   },
   {
-    heading: 'Service APIs',
-    localOnly: true,
-    blurb:
-      'OpenAPI for each service, on its own port. Production builds serve no schema at all, so these only exist when the stack runs locally.',
-    tools: [
-      {
-        title: 'Orders',
-        description: 'Orders and menu endpoints',
-        url: 'http://localhost:8003/docs',
-        badge: ':8003',
-      },
-      {
-        title: 'Delivery',
-        description: 'Delivery endpoints',
-        url: 'http://localhost:8001/docs',
-        badge: ':8001',
-      },
-      {
-        title: 'Notifications',
-        description: 'Notifications and SSE endpoints',
-        url: 'http://localhost:8002/docs',
-        badge: ':8002',
-      },
-    ],
+    title: 'Application logs',
+    description: 'Live log stream from Loki, keyed by correlation id',
+    url: '/grafana/d/application-logs/application-logs',
+  },
+  {
+    title: 'Event pipeline',
+    description: 'Stream throughput, consumer lag and the dead-letter stream',
+    url: '/grafana/d/event-pipeline/event-pipeline',
+  },
+  {
+    title: 'Prometheus',
+    description: 'Raw metrics, PromQL and scrape targets',
+    url: '/prometheus/',
+    note: 'GET only',
+  },
+];
+
+/** Every stream the services bind to, with the event types each one carries. */
+const streams: Array<{
+  stream: string;
+  producer: string;
+  consumer: string;
+  events: string[];
+  note?: string;
+}> = [
+  {
+    stream: 'orders-stream',
+    producer: 'Orders',
+    consumer: 'Delivery, Notifications',
+    events: ['order.created.v1', 'order.status_updated.v1'],
+  },
+  {
+    stream: 'deliveries-stream',
+    producer: 'Delivery',
+    consumer: 'Notifications',
+    events: ['delivery.created.v1', 'delivery.status_updated.v1'],
+  },
+  {
+    stream: 'simulate-order-stream',
+    producer: 'Orders',
+    consumer: 'Simulator',
+    events: ['order.simulate.v1'],
+  },
+  {
+    stream: 'simulate-delivery-stream',
+    producer: 'Delivery',
+    consumer: 'Simulator',
+    events: ['delivery.simulate.v1'],
+  },
+  {
+    stream: 'order-status-stream',
+    producer: 'Simulator',
+    consumer: 'Orders',
+    events: ['order.status_simulated.v1'],
+  },
+  {
+    stream: 'delivery-status-stream',
+    producer: 'Simulator',
+    consumer: 'Delivery',
+    events: ['delivery.status_simulated.v1'],
+  },
+  {
+    stream: 'ws-events',
+    producer: 'Notifications',
+    consumer: 'Notifications',
+    events: ['order.status_push.v1'],
+    note: 'one group per replica, NOACK',
+  },
+  {
+    stream: 'dead-letters',
+    producer: 'any consumer',
+    consumer: '—',
+    events: ['original payload + error'],
+    note: 'after three failures',
   },
 ];
 
@@ -94,59 +101,112 @@ const ToolCard = ({ tool }: { tool: Tool }) => (
     className="surface-card group flex flex-col gap-2 p-5 transition-transform duration-200 hover:-translate-y-0.5 active:scale-[0.99]"
   >
     <div className="flex items-start justify-between gap-3">
-      <h3 className="font-medium">{tool.title}</h3>
+      <h3 className="font-semibold">{tool.title}</h3>
       <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
     </div>
     <p className="text-sm text-muted-foreground">{tool.description}</p>
-    {(tool.badge || tool.credentials) && (
-      <div className="mt-1 flex flex-wrap gap-2">
-        {tool.badge && <span className="label">{tool.badge}</span>}
-        {tool.credentials && (
-          <code className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[0.7rem]">
-            {tool.credentials}
-          </code>
-        )}
-      </div>
-    )}
+    {tool.note && <span className="label">{tool.note}</span>}
   </a>
 );
 
 const DevTools = () => (
-  <div className="flex flex-col gap-10">
-    <header className="flex flex-col gap-3">
+  <div className="flex flex-col gap-12">
+    <header className="flex max-w-2xl flex-col gap-3">
       <p className="label">Dev tools</p>
       <h1 className="text-[2.8rem] font-semibold leading-[1.2] text-brand">
-        Look inside the running system
+        How an order actually moves
       </h1>
+      <p className="text-lg leading-relaxed text-muted-foreground">
+        Services never call each other. An order is written, an event is
+        emitted, and whoever cares reacts — so the only way to see the shape of
+        it is to follow one event across the hops.
+      </p>
     </header>
 
-    {groups.map((group) => (
-      <section key={group.heading} className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <h2 className="label">{group.heading}</h2>
-          <p className="max-w-prose text-sm text-muted-foreground">
-            {group.blurb}
-          </p>
-        </div>
+    <SystemFlow />
 
-        {group.localOnly && !isLocal ? (
-          <p className="surface-card p-5 text-sm text-muted-foreground">
-            Not reachable from here — these point at service ports on the
-            machine running the stack. Clone the repo and run{' '}
-            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.75rem]">
-              docker compose up
-            </code>{' '}
-            to browse them.
-          </p>
-        ) : (
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {group.tools.map((tool) => (
-              <ToolCard key={tool.title} tool={tool} />
+    <section className="flex flex-col gap-5">
+      <div className="flex flex-col gap-1">
+        <h2 className="label">Streams and events</h2>
+        <p className="max-w-prose text-sm text-muted-foreground">
+          Consumers read as group members, so adding a replica adds a consumer
+          and the group rebalances. A redelivery hits the inbox unique index and
+          aborts rather than applying twice.
+        </p>
+      </div>
+
+      <div className="surface-card overflow-x-auto">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="label px-5 py-3 text-left font-semibold">
+                Stream
+              </th>
+              <th className="label px-5 py-3 text-left font-semibold">
+                Produced by
+              </th>
+              <th className="label px-5 py-3 text-left font-semibold">
+                Consumed by
+              </th>
+              <th className="label px-5 py-3 text-left font-semibold">
+                Events
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {streams.map((row) => (
+              <tr
+                key={row.stream}
+                className="border-b border-border last:border-b-0"
+              >
+                <td className="px-5 py-3 font-mono text-xs">
+                  {row.stream}
+                  {row.note && (
+                    <span className="mt-1 block text-[0.7rem] text-muted-foreground">
+                      {row.note}
+                    </span>
+                  )}
+                </td>
+                <td className="px-5 py-3 text-muted-foreground">
+                  {row.producer}
+                </td>
+                <td className="px-5 py-3 text-muted-foreground">
+                  {row.consumer}
+                </td>
+                <td className="px-5 py-3">
+                  <div className="flex flex-col gap-0.5 font-mono text-xs text-muted-foreground">
+                    {row.events.map((event) => (
+                      <span key={event}>{event}</span>
+                    ))}
+                  </div>
+                </td>
+              </tr>
             ))}
-          </div>
-        )}
-      </section>
-    ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section className="flex flex-col gap-5">
+      <div className="flex flex-col gap-1">
+        <h2 className="label">Dashboards</h2>
+        <p className="max-w-prose text-sm text-muted-foreground">
+          Prometheus scrapes RED metrics and per-stream consumer lag; Loki holds
+          the logs. Consumer lag is the number to watch — streams are trimmed by
+          MAXLEN, so a stalled consumer loses events long before memory runs
+          out.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {dashboards.map((tool) => (
+          <ToolCard key={tool.title} tool={tool} />
+        ))}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Grafana asks for the credentials set on the deployment. Anonymous
+        viewing is off unless the stack was started with it enabled.
+      </p>
+    </section>
   </div>
 );
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orders-project-workspace"
-version = "0.3.2"
+version = "0.4.0"
 description = "Workspace root for all Python services"
 requires-python = ">=3.13"
 dependencies = []


### PR DESCRIPTION
The page was five links into Grafana plus a Service APIs block that could not
resolve from a deployment, which told a visitor nothing about how the system
works.

Walk one order through the hops instead: an inline SVG lights one hop at a
time while the caption explains it, stepping from the idempotent POST through
the outbox commit, the relay, the consumer groups, the durable timers and the
per-replica SSE fan-out. Every stream and event name is read off the code.

Add a streams reference in place of the dead API links, and drop the admin /
admin credential hint, which stopped being true once the prod stack started
requiring a password.
